### PR TITLE
Improve devcontainer performance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,9 @@
 		"ms-python.python"
 	],
 	"forwardPorts": [],
-	"postCreateCommand": "(cd backend && poetry install) && (cd frontend && yarn install)",
+	"mounts": [
+		"source=real-stereo-extended-node_modules,target=${containerWorkspaceFolder}/frontend/node_modules,type=volume"
+	],
+	"postCreateCommand": "(cd backend && poetry install) && (cd frontend && sudo chown vscode node_modules && yarn install)",
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
I noticed a slow performance in the frontend (yarn install && yarn build) due to the enormous amount of dependencies and the bind-volume of docker that performs not that well by default on macOS with many file reads & writes.

The change in this PR creates a separate volume for the `node_modules` folder that is not bound to the host. Meaning, the files within that folder will stay in the container and are not synced to the host. But they should still survive container rebuilds.
The result is that the performance is now near-native or even faster (because no binaries need to be built during yarn install).

Some comparison:
| Command | Host | devcontainer before change | devcontainer after change |
| - | - | - | - |
| yarn install | 30s | 7m | 26s |
| yarn build | 28s | 2m | 22-31s |

**Note**: There is one drawback. Since `node_modules` is now a volume, you can't simply `rm -rf node_modules` to do a clean install because that would delete the connection to the volume and the files would then be stored as before. Instead, you can only delete the files within the folder with `rm -rf node_modules/*`

Also, you probably need to remove the whole node_modules folder once & rebuild the container (`cmd + shift + p` > `Remote-Containers: Rebuild Container`) to get the advantages of this change.