### PR TITLE
Implement config handling and rooms/nodes api controllers

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+/config.json

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -2,10 +2,13 @@
 
 from tracking.manager import TrackingManager
 from api.manager import ApiManager
+from config import Config
 
+
+config = Config()
 
 tracking = TrackingManager()
 # tracking.start_tracking()
 
-api = ApiManager('master', tracking)
+api = ApiManager(config, tracking)
 api.start_api()

--- a/backend/src/api/controllers/nodes.py
+++ b/backend/src/api/controllers/nodes.py
@@ -1,0 +1,147 @@
+"""Controller for the /nodes namespace."""
+
+from typing import List
+from socketio import AsyncNamespace
+from config import Config
+from models.node import Node
+from models.acknowledgment import Acknowledgment
+from api.validate import Validate
+
+
+class NodesController(AsyncNamespace):
+    """Controller for the /nodes namespace."""
+
+    def __init__(self, config: Config):
+        super().__init__(namespace='/nodes')
+        self.config: Config = config
+
+    async def send_nodes(self, sid: str = None) -> None:
+        """Sends the current nodes to all clients or only a specific one.
+
+        :param str sid: If specified, nodes will only be sent to this session id. Otherwise, all
+                        clients will receive the nodes.
+        """
+        await self.emit('get', list(map(lambda node: node.to_json(True), self.config.nodes)),
+                        room=sid)
+
+    def validate(self, data: dict, create: bool) -> Acknowledgment:
+        """Validates the input data.
+
+        :param dict data: Input data
+        :param bool create: If a new node will be created from this data or an existing updated.
+        :returns: Acknowledgment with the status and possible error messages.
+        :rtype: models.acknowledgment.Acknowledgment
+        """
+        ack = Acknowledgment()
+        validate = Validate(ack)
+        node_id = data.get('id')
+        name = data.get('name')
+        ip_address = data.get('ip')
+
+        validate.string(name, label='Name', min_value=1, max_value=50)
+        validate.string(ip_address, label='Ip', min_value=3, max_value=45)
+
+        if data.get('room') is None or isinstance(data.get('room'), dict) is False:
+            ack.add_error('Room id must not be empty')
+        elif validate.integer(data.get('room').get('id'), label='Room id', min_value=1):
+            if self.config.get_room(data.get('room').get('id')) is None:
+                ack.add_error('A room with this id does not exist')
+
+        if create:
+            existing_name = next(
+                filter(lambda r: r.name == name, self.config.nodes), None)
+            existing_ip = next(
+                filter(lambda r: r.ip_address == ip_address, self.config.nodes), None)
+
+            if existing_name is not None:
+                ack.add_error('A node with this name already exists')
+            if existing_ip is not None:
+                ack.add_error('A node with this ip already exists')
+        elif validate.integer(node_id, label='Node id', min_value=1):
+            existing_name = next(
+                filter(lambda r: r.name == name, self.config.nodes), None)
+            existing_ip = next(
+                filter(lambda r: r.ip_address == ip_address, self.config.nodes), None)
+
+            if self.config.get_node(node_id) is None:
+                ack.add_error('Node with this id does not exist')
+            elif existing_name and existing_name.node_id != node_id:
+                ack.add_error('A node with this name already exists')
+            elif existing_ip and existing_ip.node_id != node_id:
+                ack.add_error('A node with this ip already exists')
+
+        return ack
+
+    async def on_get(self, _: str) -> List[Node]:
+        """Returns the current nodes.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        return list(map(lambda node: node.to_json(True), self.config.nodes))
+
+    async def on_create(self, _: str, data: dict) -> None:
+        """Creates a new node.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data, True)
+
+        # create the new node
+        if ack.successful:
+            room = self.config.get_room(data.get('room').get('id'))
+            node = Node(name=data.get('name'),
+                        ip_address=data.get('ip'), room=room)
+
+            # add the new node and send the new state to all clients
+            self.config.add_node(node)
+            ack.created_id = node.node_id
+            await self.send_nodes()
+
+        return ack.to_json()
+
+    async def on_update(self, _: str, data: dict) -> None:
+        """Updates a node.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data, False)
+
+        # update the node
+        if ack.successful:
+            room = self.config.get_room(data.get('room').get('id'))
+            node = self.config.get_node(data.get('id'))
+
+            node.name = data.get('name')
+            node.ip_address = data.get('ip')
+
+            # update room reference if necessary
+            if node.room.room_id != room.room_id:
+                node.room.nodes.remove(node)
+                node.room = room
+                node.room.nodes.append(node)
+
+            # store the update and send the new state to all clients
+            self.config.store()
+            await self.send_nodes()
+
+        return ack.to_json()
+
+    async def on_delete(self, _: str, node_id: int) -> None:
+        """Deletes a node.
+
+        :param str sid: Session id
+        :param int node_id: Node id
+        """
+        ack = Acknowledgment()
+
+        if self.config.remove_node(node_id):
+            await self.send_nodes()
+        else:
+            ack.add_error('A node with this id does not exist')
+
+        return ack.to_json()

--- a/backend/src/api/controllers/nodes.py
+++ b/backend/src/api/controllers/nodes.py
@@ -26,7 +26,7 @@ class NodesController(AsyncNamespace):
                         clients will receive the nodes.
         """
         loop = asyncio.get_event_loop()
-        loop.create_task(self.emit('get', list(map(lambda node: node.to_json(True),
+        loop.create_task(self.emit('get', list(map(lambda node: node.to_json(True, live=True),
                                                    self.config.nodes)), room=sid))
 
     def validate(self, data: dict, create: bool) -> Acknowledgment:
@@ -83,29 +83,7 @@ class NodesController(AsyncNamespace):
         :param str sid: Session id
         :param dict data: Event data
         """
-        return list(map(lambda node: node.to_json(True), self.config.nodes))
-
-    async def on_create(self, _: str, data: dict) -> None:
-        """Creates a new node.
-
-        :param str sid: Session id
-        :param dict data: Event data
-        """
-        # validate
-        ack = self.validate(data, True)
-
-        # create the new node
-        if ack.successful:
-            room = self.config.room_repository.get_room(
-                data.get('room').get('id'))
-            node = Node(name=data.get('name'),
-                        ip_address=data.get('ip'), room=room)
-
-            # add the new node and send the new state to all clients
-            self.config.node_repository.add_node(node)
-            ack.created_id = node.node_id
-
-        return ack.to_json()
+        return list(map(lambda node: node.to_json(True, live=True), self.config.nodes))
 
     async def on_update(self, _: str, data: dict) -> None:
         """Updates a node.

--- a/backend/src/api/controllers/rooms.py
+++ b/backend/src/api/controllers/rooms.py
@@ -31,27 +31,29 @@ class RoomsController(AsyncNamespace):
         :rtype: models.acknowledgement.Acknowledgement
         """
         ack = Acknowledgement()
+        room_id = data.get('id')
+        name = data.get('name')
 
-        if isinstance(data['name'], str) is False:
+        if isinstance(name, str) is False:
             ack.add_error('Name must be a string')
-        elif len(data['name']) == 0:
+        elif len(name) == 0:
             ack.add_error('Room name cannot be empty')
-        elif len(data['name']) > 50:
+        elif len(name) > 50:
             ack.add_error('Name must be at most 50 characters long')
         elif create:
             existing = next(filter(lambda r: r.name ==
-                                   data['name'], self.config.rooms), None)
+                                   name, self.config.rooms), None)
             if existing is not None:
                 ack.add_error('A room with this name already exists')
         elif not create:
             existing = next(filter(lambda r: r.name ==
-                                   data['name'], self.config.rooms), None)
+                                   name, self.config.rooms), None)
 
-            if isinstance(data['id'], int) is False:
-                ack.add_error('Room id not submitted or not with an int')
-            elif self.config.get_room(data['id']) is None:
+            if isinstance(room_id, int) is False:
+                ack.add_error('Room id must be an int')
+            elif self.config.get_room(room_id) is None:
                 ack.add_error('Room with this id does not exist')
-            elif existing and existing.room_id != data['id']:
+            elif existing and existing.room_id != room_id:
                 ack.add_error('A room with this name already exists')
 
         return ack
@@ -76,7 +78,7 @@ class RoomsController(AsyncNamespace):
 
         # create the new room
         if ack.successful:
-            room = Room(name=data['name'])
+            room = Room(name=data.get('name'))
 
             # add the new room and send the new state to all clients
             self.config.add_room(room)
@@ -96,8 +98,8 @@ class RoomsController(AsyncNamespace):
 
         # update the room
         if ack.successful:
-            room = self.config.get_room(data['id'])
-            room.name = data['name']
+            room = self.config.get_room(data.get('id'))
+            room.name = data.get('name')
 
             # store the update and send the new state to all clients
             self.config.store()

--- a/backend/src/api/controllers/rooms.py
+++ b/backend/src/api/controllers/rooms.py
@@ -1,14 +1,60 @@
 """Controller for the /rooms namespace."""
 
 from socketio import AsyncNamespace
+from config import Config
+from models.room import Room
+from models.acknowledgement import Acknowledgement
 
 
 class RoomsController(AsyncNamespace):
     """Controller for the /rooms namespace."""
 
-    def __init__(self):
+    def __init__(self, config: Config):
         super().__init__(namespace='/rooms')
-        self.rooms = []
+        self.config: Config = config
+
+    async def send_rooms(self, sid: str = None) -> None:
+        """Sends the current rooms to all clients or only a specific one.
+
+        :param str sid: If specified, rooms will only be sent to this session id. Otherwise, all
+                        clients will receive the rooms.
+        """
+        await self.emit('get', list(map(lambda room: room.to_json(True), self.config.rooms)),
+                        room=sid)
+
+    def validate(self, data: dict, create: bool) -> Acknowledgement:
+        """Validates the input data.
+
+        :param dict data: Input data
+        :param bool create: If a new room will be created from this data or an existing updated.
+        :returns: Acknowledgement with the status and possible error messages.
+        :rtype: models.acknowledgement.Acknowledgement
+        """
+        ack = Acknowledgement()
+
+        if isinstance(data['name'], str) is False:
+            ack.add_error('Name must be a string')
+        elif len(data['name']) == 0:
+            ack.add_error('Room name cannot be empty')
+        elif len(data['name']) > 50:
+            ack.add_error('Name must be at most 50 characters long')
+        elif create:
+            existing = next(filter(lambda r: r.name ==
+                                   data['name'], self.config.rooms), None)
+            if existing is not None:
+                ack.add_error('A room with this name already exists')
+        elif not create:
+            existing = next(filter(lambda r: r.name ==
+                                   data['name'], self.config.rooms), None)
+
+            if isinstance(data['id'], int) is False:
+                ack.add_error('Room id not submitted or not with an int')
+            elif self.config.get_room(data['id']) is None:
+                ack.add_error('Room with this id does not exist')
+            elif existing and existing.room_id != data['id']:
+                ack.add_error('A room with this name already exists')
+
+        return ack
 
     async def on_connect(self, sid: str, _: dict) -> None:
         """Handles connection of a new client.
@@ -17,7 +63,7 @@ class RoomsController(AsyncNamespace):
         :param dict env: Connection information
         """
         # send current state to the new client
-        await self.emit('get', self.rooms, room=sid)
+        await self.send_rooms(sid)
 
     async def on_create(self, _: str, data: dict) -> None:
         """Creates a new room.
@@ -25,6 +71,51 @@ class RoomsController(AsyncNamespace):
         :param str sid: Session id
         :param dict data: Event data
         """
-        # add the new room and send the new state to all clients
-        self.rooms.append(data)
-        await self.emit('get', self.rooms)
+        # validate
+        ack = self.validate(data, True)
+
+        # create the new room
+        if ack.successful:
+            room = Room(name=data['name'])
+
+            # add the new room and send the new state to all clients
+            self.config.add_room(room)
+            ack.created_id = room.room_id
+            await self.send_rooms()
+
+        return ack.to_json()
+
+    async def on_update(self, _: str, data: dict) -> None:
+        """Updates a room.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data, False)
+
+        # update the room
+        if ack.successful:
+            room = self.config.get_room(data['id'])
+            room.name = data['name']
+
+            # store the update and send the new state to all clients
+            self.config.store()
+            await self.send_rooms()
+
+        return ack.to_json()
+
+    async def on_delete(self, _: str, room_id: int) -> None:
+        """Deletes a room.
+
+        :param str sid: Session id
+        :param int room_id: Room id
+        """
+        ack = Acknowledgement()
+
+        if self.config.remove_room(room_id):
+            await self.send_rooms()
+        else:
+            ack.add_error('A room with this id does not exist')
+
+        return ack.to_json()

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -11,6 +11,7 @@ from numpy import ndarray
 from config import Config, NodeType
 from tracking.manager import TrackingManager
 from .controllers.rooms import RoomsController
+from .controllers.nodes import NodesController
 
 # define path of the static frontend files
 frontendPath: Path = (Path(__file__).resolve().parent /
@@ -49,6 +50,7 @@ class ApiManager:
 
             # register socket.io namespaces
             self.server.register_namespace(RoomsController(config=self.config))
+            self.server.register_namespace(NodesController(config=self.config))
 
     async def get_index(self, _: web.Request) -> web.Response:
         """Returns the index.html on the / route.

--- a/backend/src/api/validate.py
+++ b/backend/src/api/validate.py
@@ -1,0 +1,59 @@
+"""Provides validation functions."""
+
+from models.acknowledgment import Acknowledgment
+
+
+class Validate:
+    """Provides validation functions.
+
+    :param models.acknowledgment.Acknowledgment ack: Acknowledgment instance for the current request
+    """
+
+    def __init__(self, ack: Acknowledgment):
+        self.ack = ack
+
+    def string(self, value: str, label: str, min_value: int = None, max_value: int = None) -> bool:
+        """Validates if a value is a string and in the given boundaries.
+
+        :param str value: Input value that should be validated
+        :param str label: Label that will be shown in error messages
+        :param int min_value: Min length (optional)
+        :param int max_value: Max length (optional)
+        :returns: Whether the input validates
+        :rtype: bool
+        """
+        num_errors = len(self.ack.errors)
+
+        if isinstance(value, str) is False:
+            self.ack.add_error(label + ' must be a string')
+        elif min_value == 1 and len(value) == 0:
+            self.ack.add_error(label + ' must not be empty')
+        elif min_value is not None and len(value) < min_value:
+            self.ack.add_error(label + ' must be at least ' +
+                               str(min_value) + ' characters long')
+        elif max_value is not None and len(value) > max_value:
+            self.ack.add_error(label + ' must be at most ' +
+                               str(max_value) + ' characters long')
+
+        return num_errors == len(self.ack.errors)
+
+    def integer(self, value: int, label: str, min_value: int = None, max_value: int = None) -> None:
+        """Validates if a value is an integer and in the given boundaries.
+
+        :param int value: Input value that should be validated
+        :param str label: Label that will be shown in error messages
+        :param int min_value: Min value (optional)
+        :param int max_value: Max value (optional)
+        :returns: Whether the input validates
+        :rtype: bool
+        """
+        num_errors = len(self.ack.errors)
+
+        if isinstance(value, int) is False:
+            self.ack.add_error(label + ' must be an integer')
+        elif min_value is not None and value < min_value:
+            self.ack.add_error(label + ' must be at least ' + str(min_value))
+        elif max_value is not None and value > max_value:
+            self.ack.add_error(label + ' must be at most ' + str(max_value))
+
+        return num_errors == len(self.ack.errors)

--- a/backend/src/config/__init__.py
+++ b/backend/src/config/__init__.py
@@ -1,3 +1,4 @@
 """The Config module is responsible for loading, parsing and storing of the configuration file."""
+
 from .config import Config
 from .node_type import NodeType

--- a/backend/src/config/__init__.py
+++ b/backend/src/config/__init__.py
@@ -1,0 +1,3 @@
+"""The Config module is responsible for loading, parsing and storing of the configuration file."""
+from .config import Config
+from .node_type import NodeType

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -109,16 +109,75 @@ class Config:
             self.rooms.remove(room)
 
             # remove nodes with this room
-            nodes_to_remove = map(lambda n: n.room_id ==
-                                  room.room_id, self.nodes)
+            nodes_to_remove = filter(lambda n: n.room.room_id ==
+                                     room.room_id, self.nodes)
             for node in nodes_to_remove:
                 self.nodes.remove(node)
 
             # remove speakers with this room
-            speakers_to_remove = map(
-                lambda s: s.room_id == room.room_id, self.speakers)
+            speakers_to_remove = filter(
+                lambda s: s.room.room_id == room.room_id, self.speakers)
             for speaker in speakers_to_remove:
                 self.speakers.remove(speaker)
+
+            self.store()
+
+            return True
+
+        return False
+
+    def get_node(self, node_id: int, fail: bool = False) -> Node:
+        """Returns the node with the specified id.
+
+        :param int node_id: Node id
+        :param bool fail: If true, a ValueError will be raised if the node could not be found
+        :returns: Node or None if no node could be found with this id
+        :rtype: models.node.Node
+        """
+        node = next(filter(lambda r: r.node_id == node_id, self.nodes), None)
+
+        if fail and node is None:
+            raise ValueError('Node with id ' + str(node_id) +
+                             ' could not be found')
+
+        return node
+
+    def add_node(self, node: Node) -> None:
+        """Adds a new node and stores the config file.
+
+        :param models.node.Node node: Node instance
+        """
+        # assign a new id if the node does not yet have one
+        if node.node_id is None:
+            nodes_sorted = sorted(
+                self.nodes, key=lambda r: r.node_id, reverse=True)
+            node.node_id = 1 if nodes_sorted is None or len(
+                nodes_sorted) == 0 else nodes_sorted[0].node_id + 1
+
+        # add reference to room if necessary
+        if node.room is not None and node.room not in node.room.nodes:
+            node.room.nodes.append(node)
+
+        self.nodes.append(node)
+        self.store()
+
+    def remove_node(self, node_id: int) -> bool:
+        """Removes a node and stores the config file.
+
+        :param int node_id: Node id
+        :returns: False if no node could be found with this id and so no removal was possible,
+                  otherwise True.
+        :rtype: bool
+        """
+        node = self.get_node(node_id)
+
+        if node is not None:
+            # remove node
+            self.nodes.remove(node)
+
+            # remove reference on room
+            if node.room is not None:
+                node.room.nodes.remove(node)
 
             self.store()
 

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+from typing import List
+from .node_type import NodeType
+from models.room import Room
+from models.node import Node
+from models.speaker import Speaker
+
+
+class Config:
+    def __init__(self, path: Path = Path('./config.json')):
+        self.path: Path = path
+        self.type: NodeType = NodeType.UNCONFIGURED
+        self.rooms: List[Room] = []
+        self.nodes: List[Node] = []
+        self.speakers: List[Speaker] = []
+
+        # load file if it exists
+        if path.exists():
+            with open(str(path), 'r') as file:
+                self.data = json.load(file)
+                self.load()
+
+        # otherwise, create the file from a default configuration
+        else:
+            print('Config ' + str(path) +
+                  ' does not exist, creating default configuration')
+            self.store()
+
+    def load(self) -> None:
+        self.type = NodeType[self.data['type'].upper()]
+
+        # load rooms
+        for room_data in self.data['rooms']:
+            room = Room(room_id=room_data['id'], name=room_data['name'])
+            self.rooms.append(room)
+
+        # load nodes
+        for node_data in self.data['nodes']:
+            # find room in which the node is located
+            room = next(r for r in self.rooms if r.room_id ==
+                        node_data['room_id'])
+
+            if room is None:
+                raise ValueError(
+                    'Room with id ' + str(node_data['room_id']) + ' could not be found')
+
+            node = Node(node_id=node_data['id'], name=node_data['name'],
+                        ip_address=node_data['ip'], hostname=node_data['hostname'], room=room)
+            room.nodes.append(node)
+            self.nodes.append(node)
+
+        # load speakers
+        for speaker_data in self.data['speakers']:
+            # find room in which the speaker is located
+            room = next(r for r in self.rooms if r.room_id ==
+                        speaker_data['room_id'])
+
+            if room is None:
+                raise ValueError(
+                    'Room with id ' + str(speaker_data['room_id']) + ' could not be found')
+
+            speaker = Speaker(
+                speaker_id=speaker_data['id'], name=speaker_data['name'], room=room)
+            self.speakers.append(speaker)
+
+    def store(self) -> None:
+        data = {
+            'type': str(self.type).lower().split('.')[1],
+            'rooms': list(map(lambda room: room.to_json(), self.rooms)),
+            'nodes': list(map(lambda node: node.to_json(), self.nodes)),
+            'speakers': list(map(lambda speaker: speaker.to_json(), self.speakers)),
+        }
+
+        with open(str(self.path), 'w') as file:
+            json.dump(data, file)

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -64,7 +64,8 @@ class Config:
         data = {
             'type': str(self.type).lower().split('.')[1],
             'rooms': list(map(lambda room: room.to_json(), self.rooms)),
-            'nodes': list(map(lambda node: node.to_json(), self.nodes)),
+            'nodes': list(map(lambda node: node.to_json(),
+                              list(filter(lambda node: node.room is not None, self.nodes)))),
             'speakers': list(map(lambda speaker: speaker.to_json(), self.speakers)),
         }
 

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -1,13 +1,21 @@
+"""Config module implements loading, parsing and storing of the config file."""
+
 import json
 from pathlib import Path
 from typing import List
-from .node_type import NodeType
 from models.room import Room
 from models.node import Node
 from models.speaker import Speaker
+from .node_type import NodeType
 
 
 class Config:
+    """The Config class loads and parses the application config.
+    It holds all information and can write them back to the config file again.
+
+    :param Path path: Path of the config.json file
+    """
+
     def __init__(self, path: Path = Path('./config.json')):
         self.path: Path = path
         self.type: NodeType = NodeType.UNCONFIGURED
@@ -28,41 +36,23 @@ class Config:
             self.store()
 
     def load(self) -> None:
+        """Loads the configuration file and parses it into class attributes."""
         self.type = NodeType[self.data['type'].upper()]
 
         # load rooms
         for room_data in self.data['rooms']:
-            room = Room(room_id=room_data['id'], name=room_data['name'])
-            self.rooms.append(room)
+            self.rooms.append(Room.from_json(room_data))
 
         # load nodes
         for node_data in self.data['nodes']:
-            # find room in which the node is located
-            room = self.get_room(node_data['room_id'])
-
-            if room is None:
-                raise ValueError(
-                    'Room with id ' + str(node_data['room_id']) + ' could not be found')
-
-            node = Node(node_id=node_data['id'], name=node_data['name'],
-                        ip_address=node_data['ip'], hostname=node_data['hostname'], room=room)
-            room.nodes.append(node)
-            self.nodes.append(node)
+            self.nodes.append(Node.from_json(node_data, self))
 
         # load speakers
         for speaker_data in self.data['speakers']:
-            # find room in which the speaker is located
-            room = self.get_room(speaker_data['room_id'])
-
-            if room is None:
-                raise ValueError(
-                    'Room with id ' + str(speaker_data['room_id']) + ' could not be found')
-
-            speaker = Speaker(
-                speaker_id=speaker_data['id'], name=speaker_data['name'], room=room)
-            self.speakers.append(speaker)
+            self.speakers.append(Speaker.from_json(speaker_data, self))
 
     def store(self) -> None:
+        """Stores the current configuration values back in the config file."""
         data = {
             'type': str(self.type).lower().split('.')[1],
             'rooms': list(map(lambda room: room.to_json(), self.rooms)),
@@ -73,11 +63,27 @@ class Config:
         with open(str(self.path), 'w') as file:
             json.dump(data, file, indent=4)
 
-    def get_room(self, room_id: int) -> Room:
+    def get_room(self, room_id: int, fail: bool = False) -> Room:
+        """Returns the room with the specified id.
+
+        :param int room_id: Room id
+        :param bool fail: If true, a ValueError will be raised if the room could not be found
+        :returns: Room or None if no room could be found with this id
+        :rtype: models.room.Room
+        """
         room = next(filter(lambda r: r.room_id == room_id, self.rooms), None)
+
+        if fail and room is None:
+            raise ValueError('Room with id ' + str(room_id) +
+                             ' could not be found')
+
         return room
 
     def add_room(self, room: Room) -> None:
+        """Adds a new room and stores the config file.
+
+        :param models.room.Room room: Room instance
+        """
         # assign a new id if the room does not yet have one
         if room.room_id is None:
             rooms_sorted = sorted(
@@ -89,11 +95,31 @@ class Config:
         self.store()
 
     def remove_room(self, room_id: int) -> bool:
+        """Removes a room and stores the config file.
+
+        :param int room_id: Room id
+        :returns: False if no room could be found with this id and so no removal was possible,
+                  otherwise True.
+        :rtype: bool
+        """
         room = self.get_room(room_id)
 
         if room is not None:
-            # todo: also remove all nodes & speakers that were assigned to this room
+            # remove room
             self.rooms.remove(room)
+
+            # remove nodes with this room
+            nodes_to_remove = map(lambda n: n.room_id ==
+                                  room.room_id, self.nodes)
+            for node in nodes_to_remove:
+                self.nodes.remove(node)
+
+            # remove speakers with this room
+            speakers_to_remove = map(
+                lambda s: s.room_id == room.room_id, self.speakers)
+            for speaker in speakers_to_remove:
+                self.speakers.remove(speaker)
+
             self.store()
 
             return True

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -6,6 +6,8 @@ from typing import List
 from models.room import Room
 from models.node import Node
 from models.speaker import Speaker
+from repositories.room import RoomRepository
+from repositories.node import NodeRepository
 from .node_type import NodeType
 
 
@@ -22,6 +24,12 @@ class Config:
         self.rooms: List[Room] = []
         self.nodes: List[Node] = []
         self.speakers: List[Speaker] = []
+        self.room_repository = RoomRepository(self)
+        self.node_repository = NodeRepository(self)
+
+        # register repository change listeners
+        self.room_repository.register_listener(self.store)
+        self.node_repository.register_listener(self.store)
 
         # load file if it exists
         if path.exists():
@@ -62,125 +70,3 @@ class Config:
 
         with open(str(self.path), 'w') as file:
             json.dump(data, file, indent=4)
-
-    def get_room(self, room_id: int, fail: bool = False) -> Room:
-        """Returns the room with the specified id.
-
-        :param int room_id: Room id
-        :param bool fail: If true, a ValueError will be raised if the room could not be found
-        :returns: Room or None if no room could be found with this id
-        :rtype: models.room.Room
-        """
-        room = next(filter(lambda r: r.room_id == room_id, self.rooms), None)
-
-        if fail and room is None:
-            raise ValueError('Room with id ' + str(room_id) +
-                             ' could not be found')
-
-        return room
-
-    def add_room(self, room: Room) -> None:
-        """Adds a new room and stores the config file.
-
-        :param models.room.Room room: Room instance
-        """
-        # assign a new id if the room does not yet have one
-        if room.room_id is None:
-            rooms_sorted = sorted(
-                self.rooms, key=lambda r: r.room_id, reverse=True)
-            room.room_id = 1 if rooms_sorted is None or len(
-                rooms_sorted) == 0 else rooms_sorted[0].room_id + 1
-
-        self.rooms.append(room)
-        self.store()
-
-    def remove_room(self, room_id: int) -> bool:
-        """Removes a room and stores the config file.
-
-        :param int room_id: Room id
-        :returns: False if no room could be found with this id and so no removal was possible,
-                  otherwise True.
-        :rtype: bool
-        """
-        room = self.get_room(room_id)
-
-        if room is not None:
-            # remove room
-            self.rooms.remove(room)
-
-            # remove nodes with this room
-            nodes_to_remove = filter(lambda n: n.room.room_id ==
-                                     room.room_id, self.nodes)
-            for node in nodes_to_remove:
-                self.nodes.remove(node)
-
-            # remove speakers with this room
-            speakers_to_remove = filter(
-                lambda s: s.room.room_id == room.room_id, self.speakers)
-            for speaker in speakers_to_remove:
-                self.speakers.remove(speaker)
-
-            self.store()
-
-            return True
-
-        return False
-
-    def get_node(self, node_id: int, fail: bool = False) -> Node:
-        """Returns the node with the specified id.
-
-        :param int node_id: Node id
-        :param bool fail: If true, a ValueError will be raised if the node could not be found
-        :returns: Node or None if no node could be found with this id
-        :rtype: models.node.Node
-        """
-        node = next(filter(lambda r: r.node_id == node_id, self.nodes), None)
-
-        if fail and node is None:
-            raise ValueError('Node with id ' + str(node_id) +
-                             ' could not be found')
-
-        return node
-
-    def add_node(self, node: Node) -> None:
-        """Adds a new node and stores the config file.
-
-        :param models.node.Node node: Node instance
-        """
-        # assign a new id if the node does not yet have one
-        if node.node_id is None:
-            nodes_sorted = sorted(
-                self.nodes, key=lambda r: r.node_id, reverse=True)
-            node.node_id = 1 if nodes_sorted is None or len(
-                nodes_sorted) == 0 else nodes_sorted[0].node_id + 1
-
-        # add reference to room if necessary
-        if node.room is not None and node.room not in node.room.nodes:
-            node.room.nodes.append(node)
-
-        self.nodes.append(node)
-        self.store()
-
-    def remove_node(self, node_id: int) -> bool:
-        """Removes a node and stores the config file.
-
-        :param int node_id: Node id
-        :returns: False if no node could be found with this id and so no removal was possible,
-                  otherwise True.
-        :rtype: bool
-        """
-        node = self.get_node(node_id)
-
-        if node is not None:
-            # remove node
-            self.nodes.remove(node)
-
-            # remove reference on room
-            if node.room is not None:
-                node.room.nodes.remove(node)
-
-            self.store()
-
-            return True
-
-        return False

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -37,18 +37,18 @@ class Config:
 
     def load(self) -> None:
         """Loads the configuration file and parses it into class attributes."""
-        self.type = NodeType[self.data['type'].upper()]
+        self.type = NodeType[self.data.get('type').upper()]
 
         # load rooms
-        for room_data in self.data['rooms']:
+        for room_data in self.data.get('rooms'):
             self.rooms.append(Room.from_json(room_data))
 
         # load nodes
-        for node_data in self.data['nodes']:
+        for node_data in self.data.get('nodes'):
             self.nodes.append(Node.from_json(node_data, self))
 
         # load speakers
-        for speaker_data in self.data['speakers']:
+        for speaker_data in self.data.get('speakers'):
             self.speakers.append(Speaker.from_json(speaker_data, self))
 
     def store(self) -> None:

--- a/backend/src/config/node_type.py
+++ b/backend/src/config/node_type.py
@@ -1,7 +1,11 @@
+"""Available node types."""
+
 from enum import Enum
 
 
 class NodeType(Enum):
+    """Available node types."""
+
     UNCONFIGURED = 0
     MASTER = 1
     TRACKING = 2

--- a/backend/src/config/node_type.py
+++ b/backend/src/config/node_type.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class NodeType(Enum):
+    UNCONFIGURED = 0
+    MASTER = 1
+    TRACKING = 2

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,0 +1,1 @@
+"""This module holds all model classes."""

--- a/backend/src/models/acknowledgement.py
+++ b/backend/src/models/acknowledgement.py
@@ -1,14 +1,28 @@
+"""Acknowledgment holds the response to a create/update/delete API event."""
+
+
 class Acknowledgement:
+    """Acknowledgment holds the response to a create/update/delete API event."""
+
     def __init__(self):
         self.successful: bool = True
         self.created_id: int = None
         self.errors: list = []
 
     def add_error(self, error: str) -> None:
+        """Adds an error to the response. It will also set `successful` to False.
+
+        :param str error: Error message
+        """
         self.successful = False
         self.errors.append(error)
 
     def to_json(self) -> dict:
+        """Creates a JSON serializable object.
+
+        :returns: JSON serializable object
+        :rtype: dict
+        """
         json = {
             'successful': self.successful,
         }

--- a/backend/src/models/acknowledgement.py
+++ b/backend/src/models/acknowledgement.py
@@ -1,0 +1,22 @@
+class Acknowledgement:
+    def __init__(self):
+        self.successful: bool = True
+        self.created_id: int = None
+        self.errors: list = []
+
+    def add_error(self, error: str) -> None:
+        self.successful = False
+        self.errors.append(error)
+
+    def to_json(self) -> dict:
+        json = {
+            'successful': self.successful,
+        }
+
+        if self.created_id is not None:
+            json['createdId'] = self.created_id
+
+        if len(self.errors) > 0:
+            json['errors'] = self.errors
+
+        return json

--- a/backend/src/models/acknowledgment.py
+++ b/backend/src/models/acknowledgment.py
@@ -1,7 +1,7 @@
 """Acknowledgment holds the response to a create/update/delete API event."""
 
 
-class Acknowledgement:
+class Acknowledgment:
     """Acknowledgment holds the response to a create/update/delete API event."""
 
     def __init__(self):

--- a/backend/src/models/node.py
+++ b/backend/src/models/node.py
@@ -43,11 +43,12 @@ class Node:
         room.nodes.append(node)
         return node
 
-    def to_json(self, recursive: bool = False) -> dict:
+    def to_json(self, recursive: bool = False, live: bool = False) -> dict:
         """Creates a JSON serializable object.
 
         :param bool recursive: If true, all relations will be returned as full objects as well.
                                If false, only the ids of the relations will be returned.
+        :param bool live: If true, live status will be returned.
         :returns: JSON serializable object
         :rtype: dict
         """
@@ -63,5 +64,8 @@ class Node:
                 json['room'] = self.room.to_json()
             else:
                 json['room_id'] = self.room.room_id
+
+        if live:
+            json['online'] = self.online
 
         return json

--- a/backend/src/models/node.py
+++ b/backend/src/models/node.py
@@ -1,7 +1,19 @@
+"""Implements the state of a single node."""
+
 import models.room
 
 
 class Node:
+    """Implements the state of a single node.
+
+    :param int node_id: Node id
+    :param str name: Name of the node
+    :param bool online: Whether the node is currently online or not
+    :param str ip_address: Local IP adress of the node
+    :param str hostname: Hostname of the node
+    :param models.room.Room room: Room to which the node belongs to
+    """
+
     def __init__(self, node_id: int = None, name: str = '', online: bool = False,  # pylint: disable=too-many-arguments
                  ip_address: str = '', hostname: str = '', room=None):
         if len(name) == 0:
@@ -14,7 +26,31 @@ class Node:
         self.hostname: str = hostname
         self.room: models.room.Room = room
 
+    @staticmethod
+    def from_json(data: dict, config):
+        """Reads data from a JSON object and returns a new node instance.
+
+        :param dict data: JSON data
+        :param config.Config config: Config instance
+        :returns: Node
+        :rtype: Node
+        """
+        # find room in which the node is located
+        room = config.get_room(data['room_id'], fail=True)
+
+        node = Node(node_id=data['id'], name=data['name'],
+                    ip_address=data['ip'], hostname=data['hostname'], room=room)
+        room.nodes.append(node)
+        return node
+
     def to_json(self, recursive: bool = False) -> dict:
+        """Creates a JSON serializable object.
+
+        :param bool recursive: If true, all relations will be returned as full objects as well.
+                               If false, only the ids of the relations will be returned.
+        :returns: JSON serializable object
+        :rtype: dict
+        """
         json = {
             'id': self.node_id,
             'name': self.name,

--- a/backend/src/models/node.py
+++ b/backend/src/models/node.py
@@ -36,7 +36,7 @@ class Node:
         :rtype: Node
         """
         # find room in which the node is located
-        room = config.get_room(data.get('room_id'), fail=True)
+        room = config.room_repository.get_room(data.get('room_id'), fail=True)
 
         node = Node(node_id=data.get('id'), name=data.get('name'),
                     ip_address=data.get('ip'), hostname=data.get('hostname'), room=room)

--- a/backend/src/models/node.py
+++ b/backend/src/models/node.py
@@ -36,10 +36,10 @@ class Node:
         :rtype: Node
         """
         # find room in which the node is located
-        room = config.get_room(data['room_id'], fail=True)
+        room = config.get_room(data.get('room_id'), fail=True)
 
-        node = Node(node_id=data['id'], name=data['name'],
-                    ip_address=data['ip'], hostname=data['hostname'], room=room)
+        node = Node(node_id=data.get('id'), name=data.get('name'),
+                    ip_address=data.get('ip'), hostname=data.get('hostname'), room=room)
         room.nodes.append(node)
         return node
 

--- a/backend/src/models/node.py
+++ b/backend/src/models/node.py
@@ -1,0 +1,31 @@
+import models.room
+
+
+class Node:
+    def __init__(self, node_id: int = None, name: str = '', online: bool = False,  # pylint: disable=too-many-arguments
+                 ip_address: str = '', hostname: str = '', room=None):
+        if len(name) == 0:
+            raise ValueError('Node name cannot be empty')
+
+        self.node_id: int = node_id
+        self.name: str = name
+        self.online: bool = online
+        self.ip_address: str = ip_address
+        self.hostname: str = hostname
+        self.room: models.room.Room = room
+
+    def to_json(self, recursive: bool = False) -> dict:
+        json = {
+            'id': self.node_id,
+            'name': self.name,
+            'ip': self.ip_address,
+            'hostname': self.hostname,
+        }
+
+        if self.room is not None:
+            if recursive:
+                json['room'] = self.room.to_json()
+            else:
+                json['room_id'] = self.room.room_id
+
+        return json

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -44,6 +44,7 @@ class Room:
         }
 
         if recursive:
-            json['nodes'] = list(map(lambda node: node.to_json(), self.nodes))
+            json['nodes'] = list(
+                map(lambda node: node.to_json(live=True), self.nodes))
 
         return json

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -28,7 +28,7 @@ class Room:
         :returns: Room
         :rtype: Room
         """
-        return Room(data['id'], data['name'])
+        return Room(data.get('id'), data.get('name'))
 
     def to_json(self, recursive: bool = False) -> dict:
         """Creates a JSON serializable object.

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -1,0 +1,23 @@
+from typing import List
+import models.node
+
+
+class Room:
+    def __init__(self, room_id: int = None, name: str = '', nodes: List = None):
+        if len(name) == 0:
+            raise ValueError('Room name cannot be empty')
+
+        self.room_id: int = room_id
+        self.name: str = name
+        self.nodes: List[models.node.Node] = nodes or []
+
+    def to_json(self, recursive: bool = False) -> dict:
+        json = {
+            'id': self.room_id,
+            'name': self.name,
+        }
+
+        if recursive:
+            json['nodes'] = list(map(lambda node: node.to_json(), self.nodes))
+
+        return json

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -1,8 +1,17 @@
+"""Implements the state of a single room."""
+
 from typing import List
 import models.node
 
 
 class Room:
+    """Implements the state of a single room.
+
+    :param int room_id: Room id
+    :param str name: Name of the room
+    :param List[model.node.Node] nodes: All nodes that are assigned to this room
+    """
+
     def __init__(self, room_id: int = None, name: str = '', nodes: List = None):
         if len(name) == 0:
             raise ValueError('Room name cannot be empty')
@@ -11,7 +20,24 @@ class Room:
         self.name: str = name
         self.nodes: List[models.node.Node] = nodes or []
 
+    @staticmethod
+    def from_json(data: dict):
+        """Reads data from a JSON object and returns a new room instance.
+
+        :param dict data: JSON data
+        :returns: Room
+        :rtype: Room
+        """
+        return Room(data['id'], data['name'])
+
     def to_json(self, recursive: bool = False) -> dict:
+        """Creates a JSON serializable object.
+
+        :param bool recursive: If true, all relations will be returned as full objects as well.
+                               If false, only the ids of the relations will be returned.
+        :returns: JSON serializable object
+        :rtype: dict
+        """
         json = {
             'id': self.room_id,
             'name': self.name,

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -1,0 +1,25 @@
+import models.room
+
+
+class Speaker:
+    def __init__(self, speaker_id: int = None, name: str = '', room=None):
+        if len(name) == 0:
+            raise ValueError('Speaker name cannot be empty')
+
+        self.speaker_id: int = speaker_id
+        self.name: str = name
+        self.room: models.room.Room = room
+
+    def to_json(self, recursive: bool = False) -> dict:
+        json = {
+            'id': self.speaker_id,
+            'name': self.name,
+        }
+
+        if self.room is not None:
+            if recursive:
+                json['room'] = self.room
+            else:
+                json['room_id'] = self.room.room_id
+
+        return json

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -29,7 +29,7 @@ class Speaker:
         :rtype: Speaker
         """
         # find room in which the speaker is located
-        room = config.get_room(data.get('room_id'), fail=True)
+        room = config.room_repository.get_room(data.get('room_id'), fail=True)
 
         return Speaker(speaker_id=data.get('id'), name=data.get('name'), room=room)
 

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -1,7 +1,16 @@
+"""Implements the state of a single speaker."""
+
 import models.room
 
 
 class Speaker:
+    """Implements the state of a single room.
+
+    :param int speaker_id: Speaker id
+    :param str name: Name of the speaker
+    :param models.room.Room room: Room to which the speaker belongs to
+    """
+
     def __init__(self, speaker_id: int = None, name: str = '', room=None):
         if len(name) == 0:
             raise ValueError('Speaker name cannot be empty')
@@ -10,7 +19,28 @@ class Speaker:
         self.name: str = name
         self.room: models.room.Room = room
 
+    @staticmethod
+    def from_json(data: dict, config):
+        """Reads data from a JSON object and returns a new speaker instance.
+
+        :param dict data: JSON data
+        :param config.Config config: Config instance
+        :returns: Speaker
+        :rtype: Speaker
+        """
+        # find room in which the speaker is located
+        room = config.get_room(data['room_id'], fail=True)
+
+        return Speaker(speaker_id=data['id'], name=data['name'], room=room)
+
     def to_json(self, recursive: bool = False) -> dict:
+        """Creates a JSON serializable object.
+
+        :param bool recursive: If true, all relations will be returned as full objects as well.
+                               If false, only the ids of the relations will be returned.
+        :returns: JSON serializable object
+        :rtype: dict
+        """
         json = {
             'id': self.speaker_id,
             'name': self.name,

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -29,9 +29,9 @@ class Speaker:
         :rtype: Speaker
         """
         # find room in which the speaker is located
-        room = config.get_room(data['room_id'], fail=True)
+        room = config.get_room(data.get('room_id'), fail=True)
 
-        return Speaker(speaker_id=data['id'], name=data['name'], room=room)
+        return Speaker(speaker_id=data.get('id'), name=data.get('name'), room=room)
 
     def to_json(self, recursive: bool = False) -> dict:
         """Creates a JSON serializable object.

--- a/backend/src/repositories/__init__.py
+++ b/backend/src/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""This module holds all repository classes."""

--- a/backend/src/repositories/node.py
+++ b/backend/src/repositories/node.py
@@ -31,6 +31,24 @@ class NodeRepository(Repository):
 
         return node
 
+    def get_node_by_name(self, name: str) -> Node:
+        """Returns the node with the given name.
+
+        :param str name: Node name
+        :returns: Node or None if no node could be found with this name
+        :rtype: models.node.Node
+        """
+        return next(filter(lambda n: n.name == name, self.config.nodes), None)
+
+    def get_node_by_ip(self, ip_address: str) -> Node:
+        """Returns the node with the given ip address.
+
+        :param str ip: Node ip address
+        :returns: Node or None if no node could be found with this ip address
+        :rtype: models.node.Node
+        """
+        return next(filter(lambda n: n.ip_address == ip_address, self.config.nodes), None)
+
     def add_node(self, node: Node) -> None:
         """Adds a new node and stores the config file.
 
@@ -76,3 +94,11 @@ class NodeRepository(Repository):
             return True
 
         return False
+
+    def to_json(self) -> dict:
+        """Returns the list of all nodes in JSON serializable objects.
+
+        :returns: JSON serializable object
+        :rtype: dict
+        """
+        return list(map(lambda node: node.to_json(True, live=True), self.config.nodes))

--- a/backend/src/repositories/node.py
+++ b/backend/src/repositories/node.py
@@ -1,0 +1,78 @@
+"""Node repository."""
+
+from models.node import Node
+from .repository import Repository
+
+
+class NodeRepository(Repository):
+    """Node repository.
+
+    :param config.Config config: Config instance
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+    def get_node(self, node_id: int, fail: bool = False) -> Node:
+        """Returns the node with the specified id.
+
+        :param int node_id: Node id
+        :param bool fail: If true, a ValueError will be raised if the node could not be found
+        :returns: Node or None if no node could be found with this id
+        :rtype: models.node.Node
+        """
+        node = next(filter(lambda r: r.node_id ==
+                           node_id, self.config.nodes), None)
+
+        if fail and node is None:
+            raise ValueError('Node with id ' + str(node_id) +
+                             ' could not be found')
+
+        return node
+
+    def add_node(self, node: Node) -> None:
+        """Adds a new node and stores the config file.
+
+        :param models.node.Node node: Node instance
+        """
+        # assign a new id if the node does not yet have one
+        if node.node_id is None:
+            nodes_sorted = sorted(
+                self.config.nodes, key=lambda r: r.node_id, reverse=True)
+            node.node_id = 1 if nodes_sorted is None or len(
+                nodes_sorted) == 0 else nodes_sorted[0].node_id + 1
+
+        # add reference to room if necessary
+        if node.room is not None:
+            if node.room not in node.room.nodes:
+                node.room.nodes.append(node)
+            self.config.room_repository.call_listeners()
+
+        self.config.nodes.append(node)
+        self.call_listeners()
+
+    def remove_node(self, node_id: int) -> bool:
+        """Removes a node and stores the config file.
+
+        :param int node_id: Node id
+        :returns: False if no node could be found with this id and so no removal was possible,
+                  otherwise True.
+        :rtype: bool
+        """
+        node = self.get_node(node_id)
+
+        if node is not None:
+            # remove node
+            self.config.nodes.remove(node)
+
+            # remove reference on room
+            if node.room is not None:
+                node.room.nodes.remove(node)
+                self.config.room_repository.call_listeners()
+
+            self.call_listeners()
+
+            return True
+
+        return False

--- a/backend/src/repositories/repository.py
+++ b/backend/src/repositories/repository.py
@@ -1,0 +1,20 @@
+"""Base repository class containing the listener logic."""
+
+
+class Repository:
+    """Base repository class containing the listener logic."""
+
+    def __init__(self):
+        self.listeners = []
+
+    def register_listener(self, listener: callable) -> None:
+        """Register a new listener on the repository.
+
+        :param callable listener: Listener function without any arguments
+        """
+        self.listeners.append(listener)
+
+    def call_listeners(self) -> None:
+        """Calls all registered listeners."""
+        for listener in self.listeners:
+            listener()

--- a/backend/src/repositories/room.py
+++ b/backend/src/repositories/room.py
@@ -1,0 +1,82 @@
+"""Room repository."""
+
+from models.room import Room
+from .repository import Repository
+
+
+class RoomRepository(Repository):
+    """Room repository.
+
+    :param config.Config config: Config instance
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+    def get_room(self, room_id: int, fail: bool = False) -> Room:
+        """Returns the room with the specified id.
+
+        :param int room_id: Room id
+        :param bool fail: If true, a ValueError will be raised if the room could not be found
+        :returns: Room or None if no room could be found with this id
+        :rtype: models.room.Room
+        """
+        room = next(filter(lambda r: r.room_id ==
+                           room_id, self.config.rooms), None)
+
+        if fail and room is None:
+            raise ValueError('Room with id ' + str(room_id) +
+                             ' could not be found')
+
+        return room
+
+    def add_room(self, room: Room) -> None:
+        """Adds a new room and stores the config file.
+
+        :param models.room.Room room: Room instance
+        """
+        # assign a new id if the room does not yet have one
+        if room.room_id is None:
+            rooms_sorted = sorted(
+                self.config.rooms, key=lambda r: r.room_id, reverse=True)
+            room.room_id = 1 if rooms_sorted is None or len(
+                rooms_sorted) == 0 else rooms_sorted[0].room_id + 1
+
+        self.config.rooms.append(room)
+        self.call_listeners()
+
+    def remove_room(self, room_id: int) -> bool:
+        """Removes a room and stores the config file.
+
+        :param int room_id: Room id
+        :returns: False if no room could be found with this id and so no removal was possible,
+                  otherwise True.
+        :rtype: bool
+        """
+        room = self.get_room(room_id)
+
+        if room is not None:
+            # remove room
+            self.config.rooms.remove(room)
+
+            # remove nodes with this room
+            nodes_to_remove = list(filter(lambda n: n.room.room_id ==
+                                          room.room_id, self.config.nodes))
+            for node in nodes_to_remove:
+                self.config.nodes.remove(node)
+
+            if len(nodes_to_remove) > 0:
+                self.config.node_repository.call_listeners()
+
+            # remove speakers with this room
+            speakers_to_remove = filter(
+                lambda s: s.room.room_id == room.room_id, self.config.speakers)
+            for speaker in speakers_to_remove:
+                self.config.speakers.remove(speaker)
+
+            self.call_listeners()
+
+            return True
+
+        return False

--- a/backend/src/repositories/room.py
+++ b/backend/src/repositories/room.py
@@ -31,6 +31,15 @@ class RoomRepository(Repository):
 
         return room
 
+    def get_room_by_name(self, name: str) -> Room:
+        """Returns the room with the given name.
+
+        :param str name: Room name
+        :returns: Room or None if no room could be found with this name
+        :rtype: models.room.Room
+        """
+        return next(filter(lambda r: r.name == name, self.config.rooms), None)
+
     def add_room(self, room: Room) -> None:
         """Adds a new room and stores the config file.
 
@@ -80,3 +89,11 @@ class RoomRepository(Repository):
             return True
 
         return False
+
+    def to_json(self) -> dict:
+        """Returns the list of all rooms in JSON serializable objects.
+
+        :returns: JSON serializable object
+        :rtype: dict
+        """
+        return list(map(lambda room: room.to_json(True), self.config.rooms))

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -47,8 +47,10 @@ type Room = {
   id: number;
   name: string;
   nodes: Node[];
-  speakers: Speaker[];
 }
+
+type UpdateRoom = Omit<Room, 'nodes'>
+type CreateRoom = Omit<UpdateRoom, 'id'>
 ```
 
 #### `Node`
@@ -62,6 +64,15 @@ type Node = {
   hostname: string;
   room: Room;
 }
+
+type UpdateNode = Node & {
+  // only the `id` attribute of the room is needed
+  // more can still be submitted but will be ignored
+  room: {
+    id: number;
+  };
+}
+type CreateNode = Omit<UpdateNode, 'id'>
 ```
 
 #### `Speaker`
@@ -70,7 +81,17 @@ type Node = {
 type Speaker = {
   id: number;
   name: string;
+  room: Room;
 }
+
+type UpdateSpeaker = Speaker & {
+  // only the `id` attribute of the room is needed
+  // more can still be submitted but will be ignored
+  room: {
+    id: number;
+  };
+}
+type CreateSpeaker = Omit<UpdateSpeaker, 'id'>
 ```
 
 #### `Balance`
@@ -86,6 +107,7 @@ type Balance = {
 
 ```typescript
 type Settings = {
+  configured: boolean;
   balance: boolean;
 }
 ```
@@ -108,8 +130,8 @@ Lists all saved rooms.
 
 Available events:
 - `get: () => Room[]`
-- `create: (data: Room) => Acknowledgment`
-- `update: (id: number, data: Room) => Acknowledgment`
+- `create: (data: CreateRoom) => Acknowledgment`
+- `update: (data: UpdateRoom) => Acknowledgment`
 - `delete: (id: number) => Acknowledgment`
 
 #### `/nodes`
@@ -117,9 +139,19 @@ Available events:
 Lists all available nodes.
 
 Available events:
-- `get: () => PartialNode[]`
-- `create: (data: Node) => Acknowledgment`
-- `update: (id: number, data: Node) => Acknowledgment`
+- `get: () => Node[]`
+- `create: (data: CreateNode) => Acknowledgment`
+- `update: (data: UpdateNode) => Acknowledgment`
+- `delete: (id: number) => Acknowledgment`
+
+#### `/speakers`
+
+Lists all available speakers.
+
+Available events:
+- `get: () => Speaker[]`
+- `create: (data: CreateSpeaker) => Acknowledgment`
+- `update: (data: UpdateSpeaker) => Acknowledgment`
 - `delete: (id: number) => Acknowledgment`
 
 #### `/balances`

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -25,16 +25,18 @@ Availability of the events may depend on the actual resource type.
 
 #### Server Events
 
+- `get: () => Resource`<br>
+Returns the current resource in the `acknowledgment`.
 - `create: (data: Resource) => Acknowledgment`<br>
-Creates a new resource. It should contain the whole resource in the first argument. It is only available on a resource listing, not on a single resource. The `acknowledgment` will contain information about the creation success and errors.
-- `update: (id: number, data: Resource) => Acknowledgment`<br>
+Creates a new resource. It should contain the whole resource in the first argument. The `acknowledgment` will contain information about the creation success and errors.
+- `update: (data: Resource) => Acknowledgment`<br>
 Updates the specified resource. It should contain the whole resource in the first argument and is only available on a single resource, not on a resource listing. The `acknowledgment` will contain information about the update success and errors.
 - `delete: (id: number) => Acknowledgment`<br>
 Deletes the specified resource. It is only available on a single resource, not on a resource listing. The `acknowledgment` will contain information about the deletion success and errors.
 
 #### Client Events
 
-- `get: (data: Resource | Resource[])`: This event will get fired automatically after joining a namespace and when the resource gets changed. It contains the whole resource as the first argument.
+- `get: (data: Resource | Resource[])`: This event contains the whole resource as the first argument and will be triggered each time a resource gets changed.
 
 ## Protocol Documentation
 
@@ -65,14 +67,18 @@ type Node = {
   room: Room;
 }
 
-type UpdateNode = Node & {
+type CreateNode = {
+  name: string;
+  ip: string;
   // only the `id` attribute of the room is needed
   // more can still be submitted but will be ignored
   room: {
     id: number;
   };
 }
-type CreateNode = Omit<UpdateNode, 'id'>
+type UpdateNode = CreateNode & {
+  id: number;
+}
 ```
 
 #### `Speaker`

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -67,7 +67,8 @@ type Node = {
   room: Room;
 }
 
-type CreateNode = {
+type UpdateNode = {
+  id: number;
   name: string;
   ip: string;
   // only the `id` attribute of the room is needed
@@ -75,9 +76,6 @@ type CreateNode = {
   room: {
     id: number;
   };
-}
-type UpdateNode = CreateNode & {
-  id: number;
 }
 ```
 
@@ -97,7 +95,6 @@ type UpdateSpeaker = Speaker & {
     id: number;
   };
 }
-type CreateSpeaker = Omit<UpdateSpeaker, 'id'>
 ```
 
 #### `Balance`
@@ -146,7 +143,6 @@ Lists all available nodes.
 
 Available events:
 - `get: () => Node[]`
-- `create: (data: CreateNode) => Acknowledgment`
 - `update: (data: UpdateNode) => Acknowledgment`
 - `delete: (id: number) => Acknowledgment`
 
@@ -156,7 +152,6 @@ Lists all available speakers.
 
 Available events:
 - `get: () => Speaker[]`
-- `create: (data: CreateSpeaker) => Acknowledgment`
 - `update: (data: UpdateSpeaker) => Acknowledgment`
 - `delete: (id: number) => Acknowledgment`
 


### PR DESCRIPTION
This will implement the config handling, meaning all rooms, nodes and speakers will now be persisted.

The `/rooms` and `/nodes` API controllers are already fully implemented. The remaining ones will follow in a later PR as I didn't want to create a huge one (although this one is already quite big, sorry about that 😅 ).

I decided to drop the `create` event for the `/nodes` and `/speakers` as they will be auto-discovered and so created automatically. We only have to `update` them to assign them to a room. But since the auto-discovery feature is not yet implemented, this endpoint will always return an empty list. If you already want to implement it in the frontend, you can define a node manually in the `config.json` file, it will then get returned.

As discussed, clients can now emit a `get` event and will receive the current list in the acknowledgment (the server will not also emit the `get` event since nothing has changed and the other listeners don't need to re-render). Meaning, for example the rooms can be fetched initially like this: `socket.emit('get', setRooms)`. Additionally, the active state will no longer be sent automatically when a client connects.
