### PR TITLE
Implement speakers and settings api controllers

### DIFF
--- a/backend/src/api/controllers/nodes.py
+++ b/backend/src/api/controllers/nodes.py
@@ -79,7 +79,7 @@ class NodesController(AsyncNamespace):
         """
         return self.config.node_repository.to_json()
 
-    async def on_update(self, _: str, data: dict) -> None:
+    async def on_update(self, _: str, data: dict) -> dict:
         """Updates a node.
 
         :param str sid: Session id
@@ -109,7 +109,7 @@ class NodesController(AsyncNamespace):
 
         return ack.to_json()
 
-    async def on_delete(self, _: str, node_id: int) -> None:
+    async def on_delete(self, _: str, node_id: int) -> dict:
         """Deletes a node.
 
         :param str sid: Session id

--- a/backend/src/api/controllers/rooms.py
+++ b/backend/src/api/controllers/rooms.py
@@ -65,7 +65,7 @@ class RoomsController(AsyncNamespace):
         """
         return self.config.room_repository.to_json()
 
-    async def on_create(self, _: str, data: dict) -> None:
+    async def on_create(self, _: str, data: dict) -> dict:
         """Creates a new room.
 
         :param str sid: Session id
@@ -84,7 +84,7 @@ class RoomsController(AsyncNamespace):
 
         return ack.to_json()
 
-    async def on_update(self, _: str, data: dict) -> None:
+    async def on_update(self, _: str, data: dict) -> dict:
         """Updates a room.
 
         :param str sid: Session id
@@ -106,7 +106,7 @@ class RoomsController(AsyncNamespace):
 
         return ack.to_json()
 
-    async def on_delete(self, _: str, room_id: int) -> None:
+    async def on_delete(self, _: str, room_id: int) -> dict:
         """Deletes a room.
 
         :param str sid: Session id

--- a/backend/src/api/controllers/settings.py
+++ b/backend/src/api/controllers/settings.py
@@ -1,0 +1,77 @@
+"""Controller for the /settings namespace."""
+
+import asyncio
+from socketio import AsyncNamespace
+from config import Config, NodeType
+from models.acknowledgment import Acknowledgment
+from api.validate import Validate
+
+
+class SettingsController(AsyncNamespace):
+    """Controller for the /settings namespace."""
+
+    def __init__(self, config: Config):
+        super().__init__(namespace='/settings')
+        self.config: Config = config
+
+        # add settings repository change listener
+        config.setting_repository.register_listener(self.send_settings)
+
+    def build_settings(self) -> dict:
+        """Builds the settings.
+
+        :returns: Settings
+        :rtype: dict
+        """
+        return {
+            'configured': self.config.type != NodeType.UNCONFIGURED,
+            'balance': self.config.balance,
+        }
+
+    def send_settings(self, sid: str = None) -> None:
+        """Sends the current settings to all clients or only a specific one.
+
+        :param str sid: If specified, settings will only be sent to this session id. Otherwise, all
+                        clients will receive the settings.
+        """
+        loop = asyncio.get_event_loop()
+        loop.create_task(self.emit('get', self.build_settings(), room=sid))
+
+    def validate(self, data: dict) -> Acknowledgment:  # pylint: disable=no-self-use
+        """Validates the input data.
+
+        :param dict data: Input data
+        :returns: Acknowledgment with the status and possible error messages.
+        :rtype: models.acknowledgment.Acknowledgment
+        """
+        ack = Acknowledgment()
+        validate = Validate(ack)
+        balance = data.get('balance')
+
+        validate.boolean(balance, label='Balance')
+
+        return ack
+
+    async def on_get(self, _: str) -> dict:
+        """Returns the current settings.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        return self.build_settings()
+
+    async def on_update(self, _: str, data: dict) -> None:
+        """Updates the settings.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data)
+
+        # update the settings
+        if ack.successful:
+            self.config.balance = data['balance']
+            self.config.setting_repository.call_listeners()
+
+        return ack.to_json()

--- a/backend/src/api/controllers/speakers.py
+++ b/backend/src/api/controllers/speakers.py
@@ -1,0 +1,112 @@
+"""Controller for the /speakers namespace."""
+
+from typing import List
+import asyncio
+from socketio import AsyncNamespace
+from config import Config
+from models.speaker import Speaker
+from models.acknowledgment import Acknowledgment
+from api.validate import Validate
+
+
+class SpeakersController(AsyncNamespace):
+    """Controller for the /speakers namespace."""
+
+    def __init__(self, config: Config):
+        super().__init__(namespace='/speakers')
+        self.config: Config = config
+
+        # add speaker repository change listener
+        config.speaker_repository.register_listener(self.send_speakers)
+
+    def send_speakers(self, sid: str = None) -> None:
+        """Sends the current speakers to all clients or only a specific one.
+
+        :param str sid: If specified, speakers will only be sent to this session id. Otherwise, all
+                        clients will receive the speakers.
+        """
+        loop = asyncio.get_event_loop()
+        loop.create_task(
+            self.emit('get', self.config.speaker_repository.to_json(), room=sid))
+
+    def validate(self, data: dict, create: bool) -> Acknowledgment:
+        """Validates the input data.
+
+        :param dict data: Input data
+        :param bool create: If a new speaker will be created from this data or an existing updated.
+        :returns: Acknowledgment with the status and possible error messages.
+        :rtype: models.acknowledgment.Acknowledgment
+        """
+        ack = Acknowledgment()
+        validate = Validate(ack)
+        speaker_id = data.get('id')
+        name = data.get('name')
+
+        validate.string(name, label='Name', min_value=1, max_value=50)
+
+        if data.get('room') is None or isinstance(data.get('room'), dict) is False:
+            ack.add_error('Room id must not be empty')
+        elif validate.integer(data.get('room').get('id'), label='Room id', min_value=1):
+            if self.config.room_repository.get_room(data.get('room').get('id')) is None:
+                ack.add_error('A room with this id does not exist')
+
+        if create:
+            if self.config.speaker_repository.get_speaker(speaker_id) is not None:
+                ack.add_error('A speaker with this name already exists')
+        elif validate.integer(speaker_id, label='Speaker id', min_value=1):
+            existing = self.config.speaker_repository.get_speaker_by_name(name)
+
+            if self.config.speaker_repository.get_speaker(speaker_id) is None:
+                ack.add_error('A speaker with this id does not exist')
+            elif existing and existing.speaker_id != speaker_id:
+                ack.add_error('A speaker with this name already exists')
+
+        return ack
+
+    async def on_get(self, _: str) -> List[Speaker]:
+        """Returns the current speakers.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        return self.config.speaker_repository.to_json()
+
+    async def on_update(self, _: str, data: dict) -> None:
+        """Updates a speaker.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data, False)
+
+        # update the speaker
+        if ack.successful:
+            room = self.config.room_repository.get_room(
+                data.get('room').get('id'))
+            speaker = self.config.speaker_repository.get_speaker(
+                data.get('id'))
+
+            speaker.name = data.get('name')
+
+            # update room reference if necessary
+            if speaker.room.room_id != room.room_id:
+                speaker.room = room
+
+            # store the update and send the new state to all clients
+            self.config.speaker_repository.call_listeners()
+
+        return ack.to_json()
+
+    async def on_delete(self, _: str, speaker_id: int) -> None:
+        """Deletes a speaker.
+
+        :param str sid: Session id
+        :param int speaker_id: Speaker id
+        """
+        ack = Acknowledgment()
+
+        if self.config.speaker_repository.remove_speaker(speaker_id) is False:
+            ack.add_error('A speaker with this id does not exist')
+
+        return ack.to_json()

--- a/backend/src/api/controllers/speakers.py
+++ b/backend/src/api/controllers/speakers.py
@@ -71,7 +71,7 @@ class SpeakersController(AsyncNamespace):
         """
         return self.config.speaker_repository.to_json()
 
-    async def on_update(self, _: str, data: dict) -> None:
+    async def on_update(self, _: str, data: dict) -> dict:
         """Updates a speaker.
 
         :param str sid: Session id
@@ -98,7 +98,7 @@ class SpeakersController(AsyncNamespace):
 
         return ack.to_json()
 
-    async def on_delete(self, _: str, speaker_id: int) -> None:
+    async def on_delete(self, _: str, speaker_id: int) -> dict:
         """Deletes a speaker.
 
         :param str sid: Session id

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -13,6 +13,7 @@ from tracking.manager import TrackingManager
 from .controllers.rooms import RoomsController
 from .controllers.nodes import NodesController
 from .controllers.speakers import SpeakersController
+from .controllers.settings import SettingsController
 
 # define path of the static frontend files
 frontendPath: Path = (Path(__file__).resolve().parent /
@@ -54,6 +55,8 @@ class ApiManager:
             self.server.register_namespace(NodesController(config=self.config))
             self.server.register_namespace(
                 SpeakersController(config=self.config))
+            self.server.register_namespace(
+                SettingsController(config=self.config))
 
     async def get_index(self, _: web.Request) -> web.Response:
         """Returns the index.html on the / route.

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -12,6 +12,7 @@ from config import Config, NodeType
 from tracking.manager import TrackingManager
 from .controllers.rooms import RoomsController
 from .controllers.nodes import NodesController
+from .controllers.speakers import SpeakersController
 
 # define path of the static frontend files
 frontendPath: Path = (Path(__file__).resolve().parent /
@@ -51,6 +52,8 @@ class ApiManager:
             # register socket.io namespaces
             self.server.register_namespace(RoomsController(config=self.config))
             self.server.register_namespace(NodesController(config=self.config))
+            self.server.register_namespace(
+                SpeakersController(config=self.config))
 
     async def get_index(self, _: web.Request) -> web.Response:
         """Returns the index.html on the / route.

--- a/backend/src/api/validate.py
+++ b/backend/src/api/validate.py
@@ -37,7 +37,7 @@ class Validate:
 
         return num_errors == len(self.ack.errors)
 
-    def integer(self, value: int, label: str, min_value: int = None, max_value: int = None) -> None:
+    def integer(self, value: int, label: str, min_value: int = None, max_value: int = None) -> bool:
         """Validates if a value is an integer and in the given boundaries.
 
         :param int value: Input value that should be validated
@@ -57,3 +57,17 @@ class Validate:
             self.ack.add_error(label + ' must be at most ' + str(max_value))
 
         return num_errors == len(self.ack.errors)
+
+    def boolean(self, value: bool, label: str) -> None:
+        """Validates if a value is a boolean.
+
+        :param int value: Input value that should be validated
+        :param str label: Label that will be shown in error messages
+        :returns: Whether the input validates
+        :rtype: bool
+        """
+        if isinstance(value, bool) is False:
+            self.ack.add_error(label + ' must be a boolean')
+            return False
+
+        return True

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -8,6 +8,7 @@ from models.node import Node
 from models.speaker import Speaker
 from repositories.room import RoomRepository
 from repositories.node import NodeRepository
+from repositories.speaker import SpeakerRepository
 from .node_type import NodeType
 
 
@@ -26,10 +27,12 @@ class Config:
         self.speakers: List[Speaker] = []
         self.room_repository = RoomRepository(self)
         self.node_repository = NodeRepository(self)
+        self.speaker_repository = SpeakerRepository(self)
 
         # register repository change listeners
         self.room_repository.register_listener(self.store)
         self.node_repository.register_listener(self.store)
+        self.speaker_repository.register_listener(self.store)
 
         # load file if it exists
         if path.exists():
@@ -66,7 +69,9 @@ class Config:
             'rooms': list(map(lambda room: room.to_json(), self.rooms)),
             'nodes': list(map(lambda node: node.to_json(),
                               list(filter(lambda node: node.room is not None, self.nodes)))),
-            'speakers': list(map(lambda speaker: speaker.to_json(), self.speakers)),
+            'speakers': list(map(lambda speaker: speaker.to_json(),
+                                 list(filter(lambda speaker: speaker.room is not None,
+                                             self.speakers)))),
         }
 
         with open(str(self.path), 'w') as file:

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -9,6 +9,7 @@ from models.speaker import Speaker
 from repositories.room import RoomRepository
 from repositories.node import NodeRepository
 from repositories.speaker import SpeakerRepository
+from repositories.settings import SettingsRepository
 from .node_type import NodeType
 
 
@@ -22,12 +23,14 @@ class Config:
     def __init__(self, path: Path = Path('./config.json')):
         self.path: Path = path
         self.type: NodeType = NodeType.UNCONFIGURED
+        self.balance: bool = False
         self.rooms: List[Room] = []
         self.nodes: List[Node] = []
         self.speakers: List[Speaker] = []
         self.room_repository = RoomRepository(self)
         self.node_repository = NodeRepository(self)
         self.speaker_repository = SpeakerRepository(self)
+        self.setting_repository = SettingsRepository(self)
 
         # register repository change listeners
         self.room_repository.register_listener(self.store)

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -48,7 +48,7 @@ class Speaker:
 
         if self.room is not None:
             if recursive:
-                json['room'] = self.room
+                json['room'] = self.room.to_json()
             else:
                 json['room_id'] = self.room.room_id
 

--- a/backend/src/repositories/node.py
+++ b/backend/src/repositories/node.py
@@ -14,22 +14,14 @@ class NodeRepository(Repository):
         super().__init__()
         self.config = config
 
-    def get_node(self, node_id: int, fail: bool = False) -> Node:
+    def get_node(self, node_id: int) -> Node:
         """Returns the node with the specified id.
 
         :param int node_id: Node id
-        :param bool fail: If true, a ValueError will be raised if the node could not be found
         :returns: Node or None if no node could be found with this id
         :rtype: models.node.Node
         """
-        node = next(filter(lambda r: r.node_id ==
-                           node_id, self.config.nodes), None)
-
-        if fail and node is None:
-            raise ValueError('Node with id ' + str(node_id) +
-                             ' could not be found')
-
-        return node
+        return next(filter(lambda r: r.node_id == node_id, self.config.nodes), None)
 
     def get_node_by_name(self, name: str) -> Node:
         """Returns the node with the given name.

--- a/backend/src/repositories/room.py
+++ b/backend/src/repositories/room.py
@@ -79,10 +79,13 @@ class RoomRepository(Repository):
                 self.config.node_repository.call_listeners()
 
             # remove speakers with this room
-            speakers_to_remove = filter(
-                lambda s: s.room.room_id == room.room_id, self.config.speakers)
+            speakers_to_remove = list(filter(
+                lambda s: s.room.room_id == room.room_id, self.config.speakers))
             for speaker in speakers_to_remove:
                 self.config.speakers.remove(speaker)
+
+            if len(speakers_to_remove) > 0:
+                self.config.speaker_repository.call_listeners()
 
             self.call_listeners()
 

--- a/backend/src/repositories/settings.py
+++ b/backend/src/repositories/settings.py
@@ -1,0 +1,14 @@
+"""Settings repository."""
+
+from .repository import Repository
+
+
+class SettingsRepository(Repository):
+    """Settings repository.
+
+    :param config.Config config: Config instance
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config

--- a/backend/src/repositories/speaker.py
+++ b/backend/src/repositories/speaker.py
@@ -1,0 +1,60 @@
+"""Speaker repository."""
+
+from models.speaker import Speaker
+from .repository import Repository
+
+
+class SpeakerRepository(Repository):
+    """Speaker repository.
+
+    :param config.Config config: Config instance
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+    def get_speaker(self, speaker_id: int) -> Speaker:
+        """Returns the speaker with the specified id.
+
+        :param int speaker_id: Speaker id
+        :returns: Speaker or None if no speaker could be found with this id
+        :rtype: models.speaker.Speaker
+        """
+        return next(filter(lambda s: s.speaker_id == speaker_id, self.config.speakers), None)
+
+    def get_speaker_by_name(self, name: str) -> Speaker:
+        """Returns the speaker with the given name.
+
+        :param str name: Speaker name
+        :returns: Speaker or None if no speaker could be found with this name
+        :rtype: models.speaker.Speaker
+        """
+        return next(filter(lambda s: s.name == name, self.config.speakers), None)
+
+    def remove_speaker(self, speaker_id: int) -> bool:
+        """Removes a speaker and stores the config file.
+
+        :param int speaker_id: Speaker id
+        :returns: False if no speaker could be found with this id and so no removal was possible,
+                  otherwise True.
+        :rtype: bool
+        """
+        speaker = self.get_speaker(speaker_id)
+
+        if speaker is not None:
+            # remove speaker
+            self.config.speakers.remove(speaker)
+            self.call_listeners()
+
+            return True
+
+        return False
+
+    def to_json(self) -> dict:
+        """Returns the list of all speakers in JSON serializable objects.
+
+        :returns: JSON serializable object
+        :rtype: dict
+        """
+        return list(map(lambda speaker: speaker.to_json(True), self.config.speakers))

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -48,7 +48,7 @@ Deletes the specified resource. It is only available on a single resource, not o
 type Room = {
   id: number;
   name: string;
-  nodes: Node[];
+  nodes: Omit<Node, 'room'>[];
 }
 
 type UpdateRoom = Omit<Room, 'nodes'>
@@ -64,7 +64,7 @@ type Node = {
   online: boolean;
   ip: string;
   hostname: string;
-  room: Room;
+  room: Omit<Room, 'nodes'>;
 }
 
 type UpdateNode = {
@@ -85,7 +85,7 @@ type UpdateNode = {
 type Speaker = {
   id: number;
   name: string;
-  room: Room;
+  room: Omit<Room, 'nodes'>;
 }
 
 type UpdateSpeaker = Speaker & {

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -113,6 +113,10 @@ type Settings = {
   configured: boolean;
   balance: boolean;
 }
+
+type UpdateSettings = {
+  balance: boolean;
+}
 ```
 
 #### `Acknowledgment`


### PR DESCRIPTION
This implements the remaining API controllers.

The speakers also don't have a `create` event since we will fetch that list from the Sonos API. They can also only be updated (= assigned to a room). Currently, their name can be changed but that may also not be necessary since that can probably be changed in the Sonos app as well.

The settings contain the information if the balancing is currently active (for the overview), which can also be changed. Additionally, it contains the `configured` property that will be useful later when we have to detect if this node needs to be set up for the first time (e.g. define Wifi access).