### PR TITLE
Sonos volume control

### DIFF
--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -17,6 +17,7 @@ if config.type == NodeType.MASTER or '--master' in argv:
     cluster_master = ClusterMaster(config)
     cluster_master.start()
     balancing.start_discovery()
+    balancing.start_control()
 else:
     cluster_slave = ClusterSlave()
     cluster_slave.start()

--- a/backend/src/balancing/manager.py
+++ b/backend/src/balancing/manager.py
@@ -34,13 +34,13 @@ class BalancingManager:
         if self.control_thread is not None:
             return
         print('[Balancing] Starting sonos control loop')
-        self.control_thread = Thread(target=self.sonos.discover_loop)
+        self.control_thread = Thread(target=self.sonos.control_loop)
         self.control_thread.start()
 
     def stop_control(self) -> None:
         """Stop the control loop"""
         if self.control_thread is not None:
             print('[Balancing] Stopping sonos control loop')
-            self.sonos.stop_discover_loop()
+            self.sonos.stop_control_loop()
             self.control_thread.join()
             self.control_thread = None

--- a/backend/src/balancing/manager.py
+++ b/backend/src/balancing/manager.py
@@ -1,7 +1,6 @@
 """Handles sonos discovery and control."""
 from threading import Thread
 from config import Config
-from models.speaker import Speaker
 from .sonos import Sonos
 
 
@@ -12,6 +11,7 @@ class BalancingManager:
         self.config = config
         self.sonos = Sonos(config)
         self.discover_thread = None
+        self.control_thread = None
 
     def start_discovery(self) -> None:
         """Start the discovery loop"""
@@ -28,3 +28,19 @@ class BalancingManager:
             self.sonos.stop_discover_loop()
             self.discover_thread.join()
             self.discover_thread = None
+
+    def start_control(self) -> None:
+        """Start the control loop"""
+        if self.control_thread is not None:
+            return
+        print('[Balancing] Starting sonos control loop')
+        self.control_thread = Thread(target=self.sonos.discover_loop)
+        self.control_thread.start()
+
+    def stop_control(self) -> None:
+        """Stop the control loop"""
+        if self.control_thread is not None:
+            print('[Balancing] Stopping sonos control loop')
+            self.sonos.stop_discover_loop()
+            self.control_thread.join()
+            self.control_thread = None

--- a/backend/src/balancing/sonos.py
+++ b/backend/src/balancing/sonos.py
@@ -1,47 +1,60 @@
 """Implements Sonos discovery and control"""
 from time import sleep
+from queue import SimpleQueue
 import asyncio
 from config import Config
 from models.speaker import Speaker
-import soco
+from sonos.adapter import SonosAdapter
+from sonos.adapter_soco import SonosSocoAdapter
 
 
 class Sonos:
     """Performs discovery for Sonos speakers and sends messages to control them."""
 
     def __init__(self, config: Config):
-        self.discover_loop_exiting = False
         self.config = config
+        self.sonos_adapter: SonosAdapter = SonosSocoAdapter()
+        self.discover_loop_exiting = False
+        self.control_loop_exiting = False
+        self.control_queue = SimpleQueue()
 
     def discover_loop(self):
         """Starts the discover loop which runs every 15 seconds until stopped"""
         self.discover_loop_exiting = False
         asyncio.set_event_loop(asyncio.new_event_loop())
         while not self.discover_loop_exiting:
-            players: set[soco.SoCo] = soco.discover()
-            for player in players:
-                existing_speaker = self.config.speaker_repository.get_speaker(player.uid)
+            speakers = self.sonos_adapter.discover()
+            speaker: Speaker
+            for speaker in speakers:
+                existing_speaker = self.config.speaker_repository.get_speaker(speaker.speaker_id)
                 if existing_speaker is not None and \
-                        existing_speaker.name == player.player_name and \
-                        existing_speaker.ip_address == player.ip_address:
+                        existing_speaker.name == speaker.name and \
+                        existing_speaker.ip_address == speaker.ip_address:
                     continue
                 elif existing_speaker is not None:
-                    existing_speaker.name = player.player_name
-                    existing_speaker.ip_address = player.ip_address
+                    existing_speaker.name = speaker.name
+                    existing_speaker.ip_address = speaker.ip_address
                     self.config.speaker_repository.call_listeners()
                     continue
-                print('[Balancing] Discovered new Sonos player {} with uid {} at {}, Coordinator: {}'
+                print('[Balancing] Discovered new Sonos speaker {} with uid {} at {}'
                       .format(
-                          player.player_name,
-                          player.uid,
-                          player.ip_address,
-                          player.is_coordinator
+                          speaker.name,
+                          speaker.speaker_id,
+                          speaker.ip_address,
                       ))
-                speaker = Speaker(speaker_id=player.uid, name=player.player_name,
-                                  ip_address=player.ip_address)
                 self.config.speaker_repository.add_speaker(speaker)
             sleep(15)
 
     def stop_discover_loop(self):
         """Sets the flag to stop the discover loop"""
         self.discover_loop_exiting = True
+
+    def control_loop(self):
+        """Starts the control loop which consumes all control commands in the queue"""
+        self.control_loop_exiting = False
+        while not self.control_loop_exiting:
+            command = self.control_queue.get()
+
+    def stop_control_loop(self):
+        """Sets the flag to stop the control loop"""
+        self.control_loop_exiting = True

--- a/backend/src/balancing/sonos.py
+++ b/backend/src/balancing/sonos.py
@@ -21,10 +21,13 @@ class Sonos:
             players: set[soco.SoCo] = soco.discover()
             for player in players:
                 existing_speaker = self.config.speaker_repository.get_speaker(player.uid)
-                if existing_speaker is not None and existing_speaker.name == player.player_name:
+                if existing_speaker is not None and \
+                        existing_speaker.name == player.player_name and \
+                        existing_speaker.ip_address == player.ip_address:
                     continue
                 elif existing_speaker is not None:
                     existing_speaker.name = player.player_name
+                    existing_speaker.ip_address = player.ip_address
                     self.config.speaker_repository.call_listeners()
                     continue
                 print('[Balancing] Discovered new Sonos player {} with uid {} at {}, Coordinator: {}'
@@ -34,7 +37,8 @@ class Sonos:
                           player.ip_address,
                           player.is_coordinator
                       ))
-                speaker = Speaker(speaker_id=player.uid, name=player.player_name)
+                speaker = Speaker(speaker_id=player.uid, name=player.player_name,
+                                  ip_address=player.ip_address)
                 self.config.speaker_repository.add_speaker(speaker)
             sleep(15)
 

--- a/backend/src/balancing/sonos.py
+++ b/backend/src/balancing/sonos.py
@@ -6,6 +6,7 @@ from config import Config
 from models.speaker import Speaker
 from sonos.adapter import SonosAdapter
 from sonos.adapter_soco import SonosSocoAdapter
+from .sonos_command import SonosCommand
 
 
 class Sonos:
@@ -53,8 +54,13 @@ class Sonos:
         """Starts the control loop which consumes all control commands in the queue"""
         self.control_loop_exiting = False
         while not self.control_loop_exiting:
-            command = self.control_queue.get()
+            command: SonosCommand = self.control_queue.get()
+            command.run(self.sonos_adapter)
 
     def stop_control_loop(self):
         """Sets the flag to stop the control loop"""
         self.control_loop_exiting = True
+
+    def send_command(self, command: SonosCommand):
+        """Adds the command to the control queue"""
+        self.control_queue.put(command)

--- a/backend/src/balancing/sonos_command.py
+++ b/backend/src/balancing/sonos_command.py
@@ -1,6 +1,8 @@
 """Contains information of the command to be sent to a Sonos speaker"""
 from abc import ABC, abstractmethod
+from typing import List
 from models.speaker import Speaker
+from sonos.adapter import SonosAdapter
 
 
 class SonosCommand(ABC):
@@ -9,11 +11,11 @@ class SonosCommand(ABC):
     :param list[Speaker] speakers: Speakers where the command should be sent to
     """
 
-    def __init__(self, speakers: list[Speaker]):
+    def __init__(self, speakers: List[Speaker]):
         self.speakers = speakers
 
     @abstractmethod
-    def run(self):
+    def run(self, sonos_adapter: SonosAdapter):
         """Executes the command"""
 
 
@@ -26,7 +28,15 @@ class SonosVolumeCommand(SonosCommand):
                                 Sonos speaker (ramp rate is 1.25 steps per second)
     """
 
-    def __init__(self, speakers: list[Speaker], volumes: list[int], ramp_to_volume: bool = False):
+    def __init__(self, speakers: List[Speaker], volumes: List[int], ramp_to_volume: bool = False):
         super().__init__(speakers)
         self.volumes = volumes
         self.ramp_to_volume = ramp_to_volume
+
+    def run(self, sonos_adapter: SonosAdapter):
+        """Executes the command"""
+        for index, speaker in enumerate(self.speakers):
+            if not self.ramp_to_volume:
+                sonos_adapter.set_volume(speaker=speaker, volume=self.volumes[index])
+            else:
+                sonos_adapter.ramp_to_volume(speaker=speaker, volume=self.volumes[index])

--- a/backend/src/balancing/sonos_command.py
+++ b/backend/src/balancing/sonos_command.py
@@ -1,0 +1,32 @@
+"""Contains information of the command to be sent to a Sonos speaker"""
+from abc import ABC, abstractmethod
+from models.speaker import Speaker
+
+
+class SonosCommand(ABC):
+    """Contains information of the command to be sent to a Sonos speaker
+
+    :param list[Speaker] speakers: Speakers where the command should be sent to
+    """
+
+    def __init__(self, speakers: list[Speaker]):
+        self.speakers = speakers
+
+    @abstractmethod
+    def run(self):
+        """Executes the command"""
+
+
+class SonosVolumeCommand(SonosCommand):
+    """Contains information of the volume command to be sent to a Sonos speaker
+
+    :param list[Speaker] speakers: Speakers where the command should be sent to
+    :param list[int] volume: The volumes to be set, values between 0 and 100
+    :param bool ramp_to_volume: If the volume should be changed smoothly by the
+                                Sonos speaker (ramp rate is 1.25 steps per second)
+    """
+
+    def __init__(self, speakers: list[Speaker], volumes: list[int], ramp_to_volume: bool = False):
+        super().__init__(speakers)
+        self.volumes = volumes
+        self.ramp_to_volume = ramp_to_volume

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -11,14 +11,17 @@ class Speaker:
     :param models.room.Room room: Room to which the speaker belongs to
     """
 
-    def __init__(self, speaker_id: str, name: str = '', room=None):
+    def __init__(self, speaker_id: str, name: str = '', ip_address: str = '', room=None):
         if len(speaker_id) == 0:
             raise ValueError('Speaker id cannot be empty')
         if len(name) == 0:
             raise ValueError('Speaker name cannot be empty')
+        if len(ip_address) == 0:
+            raise ValueError('Speaker ip_address cannot be empty')
 
         self.speaker_id: str = speaker_id
         self.name: str = name
+        self.ip_address: str = ip_address
         self.room: models.room.Room = room
 
     @staticmethod
@@ -33,7 +36,7 @@ class Speaker:
         # find room in which the speaker is located
         room = config.room_repository.get_room(data.get('room_id'), fail=True)
 
-        return Speaker(speaker_id=data.get('id'), name=data.get('name'), room=room)
+        return Speaker(speaker_id=data.get('id'), name=data.get('name'), ip_address=data.get('ip_address'), room=room)
 
     def to_json(self, recursive: bool = False) -> dict:
         """Creates a JSON serializable object.
@@ -46,6 +49,7 @@ class Speaker:
         json = {
             'id': self.speaker_id,
             'name': self.name,
+            'ip_address': self.ip_address,
         }
 
         if self.room is not None:

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -1,5 +1,4 @@
 """Implements the state of a single speaker."""
-
 import models.room
 
 

--- a/backend/src/sonos/__init__.py
+++ b/backend/src/sonos/__init__.py
@@ -1,0 +1,1 @@
+"""Holds all Sonos adapters"""

--- a/backend/src/sonos/adapter.py
+++ b/backend/src/sonos/adapter.py
@@ -28,6 +28,7 @@ class SonosAdapter(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def ramp_to_volume(self, speaker: Speaker, volume: int):
         """Ramps volume to target volume for the passed Sonos speaker
 

--- a/backend/src/sonos/adapter.py
+++ b/backend/src/sonos/adapter.py
@@ -1,0 +1,20 @@
+"""Defines methods to send commands to Sonos speakers"""
+from abc import ABC, abstractmethod
+from typing import Set
+from models.speaker import Speaker
+
+
+class SonosAdapter(ABC):
+    """Defines methods to send commands to Sonos speakers"""
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def discover(self) -> Set[Speaker]:
+        """Discovers local Sonos speakers
+
+        :returns: Set of discovered speakers
+        :rtype: set[models.speaker.Speaker]
+        """
+        raise NotImplementedError()

--- a/backend/src/sonos/adapter.py
+++ b/backend/src/sonos/adapter.py
@@ -18,3 +18,20 @@ class SonosAdapter(ABC):
         :rtype: set[models.speaker.Speaker]
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def set_volume(self, speaker: Speaker, volume: int):
+        """Sets volume for passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker to control
+        :param int volume: Volume to set
+        """
+        raise NotImplementedError()
+
+    def ramp_to_volume(self, speaker: Speaker, volume: int):
+        """Ramps volume to target volume for the passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker to control
+        :param int volume: Volume to ramp up or down to
+        """
+        raise NotImplementedError()

--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -1,0 +1,22 @@
+"""Defines methods to send commands to Sonos speakers using the soco library"""
+from typing import Set
+from models.speaker import Speaker
+import soco
+from .adapter import SonosAdapter
+
+
+class SonosSocoAdapter(SonosAdapter):
+    """Defines methods to send commands to Sonos speakers using the soco library"""
+
+    def discover(self) -> Set[Speaker]:
+        """Discovers local Sonos speakers
+
+        :returns: Set of discovered speakers
+        :rtype: set[models.speaker.Speaker]
+        """
+        speakers = set()
+        speaker: soco.SoCo
+        for speaker in soco.discover():
+            speakers.add(Speaker(speaker_id=speaker.uid,
+                                 name=speaker.player_name, ip_address=speaker.ip_address))
+        return speakers

--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -20,3 +20,21 @@ class SonosSocoAdapter(SonosAdapter):
             speakers.add(Speaker(speaker_id=speaker.uid,
                                  name=speaker.player_name, ip_address=speaker.ip_address))
         return speakers
+
+    def set_volume(self, speaker: Speaker, volume: int):
+        """Sets volume for passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker to control
+        :param int volume: Volume to set
+        """
+        soco_instance = soco.SoCo(speaker.ip_address)
+        soco_instance.volume = volume
+
+    def ramp_to_volume(self, speaker: Speaker, volume: int):
+        """Ramps volume to target volume for the passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker to control
+        :param int volume: Volume to ramp up or down to
+        """
+        soco_instance = soco.SoCo(speaker.ip_address)
+        soco_instance.ramp_to_volume(volume)


### PR DESCRIPTION
This adds the Sonos control thread which will be used for all control signals that should be sent to the speakers. The main thread can add `SonosCommand` instances to the command `Queue` which will get handled FIFO.

This also adds the `SonosVolumeCommand` class which is used for volume change commands. It accepts a list of speakers and a list of volumes, so we can change multiple speakers with one function call.

Additionally this abstracts all interaction with the `SoCo` library into it's adapter `SonosSocoAdapter` and uses our own Speaker class outside of the adapter so we can replace this library in the future, if we need to.
The `SonosSocoAdapter` makes sure that stereo pair masters can have their volume set independently without affecting their slaves using a hacky workaround (if you have a better idea for this, please let me know 😅).