### PR TITLE
Run image processing in separate processes

### DIFF
--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -32,6 +32,7 @@ async def main():
             balancing.start_discovery(),
             balancing.start_control(),
             tracking.await_frames(),
+            tracking.await_coordinates(),
         )
     else:
         cluster_slave = ClusterSlave(config, tracking)

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -43,6 +43,8 @@ async def main():
             cluster_slave.start(),
             api.start(),
             tracking.await_frames(),
+            tracking.await_coordinates(),
+            tracking.await_camera_calibration_responses(),
         )
 
 

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -33,6 +33,7 @@ async def main():
             balancing.start_control(),
             tracking.await_frames(),
             tracking.await_coordinates(),
+            tracking.await_camera_calibration_responses(),
         )
     else:
         cluster_slave = ClusterSlave(config, tracking)

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -92,7 +92,7 @@ class ApiManager:
             print('[Web API] Starting camera stream')
             self.tracking_manager.set_frame_callback(self.on_frame)
 
-        if self.tracking_manager.running is False:
+        if self.tracking_manager.is_camera_active() is False:
             await self.write_camera_inactive_frame(response)
 
         self.tracking_manager.acquire_camera()

--- a/backend/src/protocol/slave/slave.py
+++ b/backend/src/protocol/slave/slave.py
@@ -178,13 +178,7 @@ class ClusterSlave(ClusterSocket):
             finish = message.cameraCalibrationRequest.finish or False
             repeat = message.cameraCalibrationRequest.repeat or False
 
-            def on_tracking_started():
-                self.tracking.on_start = None
-                self.tracking.camera.calibration.cluster_slave = self
-                self.tracking.camera.calibration.handle_request(start=start, finish=finish,
-                                                                repeat=repeat)
-
-            self.tracking.on_start = on_tracking_started
+            self.tracking.send_camera_calibration_request(start, finish, repeat, self)
 
             if start:
                 self.tracking.acquire_camera()

--- a/backend/src/tracking/fps_calculator.py
+++ b/backend/src/tracking/fps_calculator.py
@@ -1,0 +1,29 @@
+"""Calculates the performance in form of frames per seconds."""
+
+from time import time
+from collections import deque
+
+
+class Fps:
+    """Calculates the performance in form of frames per seconds.
+
+    :param int size: Number of frames to average
+    """
+
+    def __init__(self, size: int = 10):
+        self.frames = deque(maxlen=size)
+
+    def frame(self) -> None:
+        """Store a new frame."""
+        self.frames.append(time())
+
+    def get(self) -> float:
+        """Get the average FPS.
+
+        :returns: Average FPS
+        :rtype: float
+        """
+        if len(self.frames) < 2:
+            return 0.0
+
+        return len(self.frames) / (self.frames[-1] - self.frames[0])

--- a/backend/src/tracking/hog_grayscale_people_detector.py
+++ b/backend/src/tracking/hog_grayscale_people_detector.py
@@ -7,7 +7,7 @@ from .hog_people_detector import HogPeopleDetector
 class HogGrayscalePeopleDetector(HogPeopleDetector):
     """Detects people in a given grayscale camera frame."""
 
-    async def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
+    def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
         """Detects people in a given camera frame.
 
         :param numpy.ndarray detection_frame: Camera frame which should be used for detection
@@ -15,4 +15,4 @@ class HogGrayscalePeopleDetector(HogPeopleDetector):
                                          If none, result should be drawn in detection_frame.
         """
         gray_frame = cv2.cvtColor(detection_frame, cv2.COLOR_BGR2GRAY)
-        return await super().detect(gray_frame, detection_frame)
+        return super().detect(gray_frame, detection_frame)

--- a/backend/src/tracking/hog_people_detector.py
+++ b/backend/src/tracking/hog_people_detector.py
@@ -1,20 +1,20 @@
 """Detects people in a given camera frame."""
+from multiprocessing import Queue, Event
 import cv2
 from numpy import ndarray
 from imutils.object_detection import non_max_suppression
-from config import Config
 from .people_detector import PeopleDetector
 
 
 class HogPeopleDetector(PeopleDetector):
     """Detects people in a given camera frame."""
 
-    def __init__(self, config: Config):
-        super().__init__(config)
+    def __init__(self, frame_queue: Queue, frame_result_queue: Queue, return_frame: Event):
+        super().__init__(frame_queue, frame_result_queue, return_frame)
         self.hog = cv2.HOGDescriptor()
         self.hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
 
-    async def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
+    def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
         """Detects people in a given camera frame.
 
         :param numpy.ndarray detection_frame: Camera frame which should be used for detection
@@ -31,7 +31,7 @@ class HogPeopleDetector(PeopleDetector):
         # calculate the coordinate
         if len(reduced_rects) > 0:
             coordinate = self.calculate_coordinate(reduced_rects)
-            await self.report_coordinate(coordinate)
+            self.report_coordinate(coordinate)
 
         # draw the bounding boxes
         self.draw_rects(draw_frame if draw_frame is not None else detection_frame, reduced_rects)

--- a/backend/src/tracking/hog_people_detector.py
+++ b/backend/src/tracking/hog_people_detector.py
@@ -9,8 +9,9 @@ from .people_detector import PeopleDetector
 class HogPeopleDetector(PeopleDetector):
     """Detects people in a given camera frame."""
 
-    def __init__(self, frame_queue: Queue, frame_result_queue: Queue, return_frame: Event):
-        super().__init__(frame_queue, frame_result_queue, return_frame)
+    def __init__(self, frame_queue: Queue, frame_result_queue: Queue, return_frame: Event,
+                 coordinate_queue: Queue):
+        super().__init__(frame_queue, frame_result_queue, return_frame, coordinate_queue)
         self.hog = cv2.HOGDescriptor()
         self.hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
 

--- a/backend/src/tracking/manager.py
+++ b/backend/src/tracking/manager.py
@@ -1,7 +1,22 @@
 """Handles the camera processing."""
 
+import multiprocessing
 import asyncio
+from concurrent.futures import ProcessPoolExecutor
 from .camera import Camera
+from .hog_grayscale_people_detector import HogGrayscalePeopleDetector
+
+
+def start_camera(frame_queue, frame_result_queue, return_frame, detection_active) -> None:
+    """Starts the camera in a subprocess."""
+    camera = Camera(frame_queue, frame_result_queue, return_frame, detection_active)
+    camera.process()
+
+
+def start_detector(frame_queue, frame_result_queue, return_frame) -> None:
+    """Starts the people detector in a subprocess."""
+    detector = HogGrayscalePeopleDetector(frame_queue, frame_result_queue, return_frame)
+    detector.process()
 
 
 class TrackingManager:
@@ -10,28 +25,41 @@ class TrackingManager:
     def __init__(self, config):
         self.config = config
         self.camera = None
-        self.running = False
+        self.detector = None
         self.on_frame = None
-        self.on_start = None
         self.config.setting_repository.register_listener(self.on_settings_changed)
         self.previous_config_value = self.config.balance
         self.camera_listeners = 0
+
+        manager = multiprocessing.Manager()
+        self.frame_queue = manager.Queue()
+        self.frame_result_queue = manager.Queue()
+        self.detection_active = manager.Event()
+        self.return_frame = manager.Event()
 
     async def on_settings_changed(self) -> None:
         """Update the tracking status when the settings have changed."""
         if self.config.balance and self.config.balance != self.previous_config_value:
             self.acquire_camera()
+            self.start_detector()
         elif self.config.balance is False and self.config.balance != self.previous_config_value:
             self.release_camera()
+            self.stop_detector()
 
         self.previous_config_value = self.config.balance
 
+    def is_camera_active(self) -> bool:
+        """Returns whether the camera is active.
+
+        :returns: True if the camera is active
+        :rtype: bool
+        """
+        return self.camera is not None
+
     def acquire_camera(self) -> None:
         """Ensures the tracking is running."""
-        if self.running is False:
-            asyncio.create_task(self.start())
-        elif self.on_start is not None:
-            self.on_start()  # pylint: disable=not-callable
+        if self.camera is None:
+            self.start_camera()
 
         self.camera_listeners += 1
         print('[Tracking] Camera acquired ({})'.format(self.camera_listeners))
@@ -42,35 +70,53 @@ class TrackingManager:
         print('[Tracking] Camera released ({})'.format(self.camera_listeners))
 
         if self.camera_listeners == 0:
-            self.stop()
+            self.stop_camera()
 
-    async def start(self) -> None:
+    def start_camera(self) -> None:
         """Start the camera tracking."""
-        self.running = True
-
-        print('[Tracking] Starting camera')
-
         if self.camera is None:
-            self.camera = Camera(self.config)
-            self.camera.set_frame_callback(self.on_frame)
+            print('[Tracking] Starting camera')
+            self.camera = multiprocessing.Process(
+                target=start_camera, args=(self.frame_queue, self.frame_result_queue,
+                                           self.return_frame, self.detection_active, ))
+            self.camera.start()
+            #self.camera = Camera(self.config)
+            # self.camera.set_frame_callback(self.on_frame)
 
-        if self.on_start is not None:
-            self.on_start()  # pylint: disable=not-callable
+    def start_detector(self) -> None:
+        """Start the people detector."""
+        if self.detector is None:
+            print('[Tracking] Starting people detector')
+            self.detection_active.set()
+            self.detector = multiprocessing.Process(
+                target=start_detector, args=(self.frame_queue, self.frame_result_queue,
+                                             self.return_frame, ))
+            self.detector.start()
 
-        await self.camera.process()
-
-    def stop(self) -> None:
+    def stop_camera(self) -> None:
         """Stop the current camera tracking."""
-        self.running = False
-
         if self.camera is not None:
             print('[Tracking] Stopping camera')
-            self.camera.stop()
+            self.camera.kill()
             self.camera = None
 
-    def is_active(self) -> bool:
-        """Returns if the tracking is currently running."""
-        return self.running
+    def stop_detector(self) -> None:
+        """Stop the people detector."""
+        if self.detector is not None:
+            print('[Tracking] Stopping people detector')
+            self.detection_active.clear()
+            self.detector.kill()
+            self.detector = None
+
+    async def await_frames(self) -> None:
+        """Awaits result frames and passes them to the listener."""
+        executor = ProcessPoolExecutor(max_workers=1)
+        loop = asyncio.get_running_loop()
+
+        while True:
+            frame = await loop.run_in_executor(executor, self.frame_result_queue.get)
+            if self.on_frame is not None:
+                self.on_frame(frame)
 
     def set_frame_callback(self, on_frame: callable) -> None:
         """Sets the `on_frame` callback that will receive every processed frame.
@@ -81,5 +127,7 @@ class TrackingManager:
         """
         self.on_frame = on_frame
 
-        if self.camera is not None:
-            self.camera.set_frame_callback(on_frame)
+        if self.on_frame is not None:
+            self.return_frame.set()
+        else:
+            self.return_frame.clear()

--- a/backend/src/tracking/people_detector.py
+++ b/backend/src/tracking/people_detector.py
@@ -1,17 +1,40 @@
 """Defines methods for the people detection."""
 from abc import ABC, abstractmethod
+from multiprocessing import Queue, Event
 from numpy import ndarray
-from config import Config
+import cv2
+from .fps_calculator import Fps
 
 
 class PeopleDetector(ABC):
     """Defines methods for the people detection."""
 
-    def __init__(self, config: Config):
-        self.config = config
+    def __init__(self, frame_queue: Queue, frame_result_queue: Queue, return_frame: Event):
+        self.frame_queue = frame_queue
+        self.frame_result_queue = frame_result_queue
+        self.return_frame = return_frame
+        self.fps = Fps()
+
+    def process(self) -> None:
+        """Starts people detection."""
+        while True:
+            frame = self.frame_queue.get()
+            self.detect(frame, frame)
+
+            # count fps
+            self.fps.frame()
+            print('Detection FPS: {}'.format(self.fps.get()))
+
+            if self.return_frame.is_set():
+                # write fps on the image
+                cv2.putText(frame, 'FPS: {:.1f}'.format(self.fps.get()), (10, 26),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 0), 2)
+
+                # send result
+                self.frame_result_queue.put_nowait(frame)
 
     @abstractmethod
-    async def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
+    def detect(self, detection_frame: ndarray, draw_frame: ndarray = None) -> None:
         """Detects people in a given camera frame.
 
         :param numpy.ndarray detection_frame: Camera frame which should be used for detection
@@ -20,9 +43,10 @@ class PeopleDetector(ABC):
         """
         raise NotImplementedError()
 
-    async def report_coordinate(self, coordinate: int) -> None:
+    def report_coordinate(self, coordinate: int) -> None:
         """Reports the detected coordinate to the master.
 
         :param int coordinate: Coordinate
         """
-        await self.config.tracking_repository.update_coordinate(coordinate)
+        print('Detected coordinate: {}'.format(coordinate))
+        # await self.config.tracking_repository.update_coordinate(coordinate)

--- a/backend/src/tracking/people_detector.py
+++ b/backend/src/tracking/people_detector.py
@@ -23,7 +23,6 @@ class PeopleDetector(ABC):
 
             # count fps
             self.fps.frame()
-            print('Detection FPS: {}'.format(self.fps.get()))
 
             if self.return_frame.is_set():
                 # write fps on the image
@@ -48,5 +47,4 @@ class PeopleDetector(ABC):
 
         :param int coordinate: Coordinate
         """
-        print('Detected coordinate: {}'.format(coordinate))
         # await self.config.tracking_repository.update_coordinate(coordinate)


### PR DESCRIPTION
There are now two additional processes:
- One that constantly captures a camera frame and corrects it (regarding the fisheye distortion)
- A second one that runs the detection algorithm on the last frame from the other process

There is a bit of an improvement, but as 90% of the time is taken by the detection algorithm (which can't be parallelized, unfortunately), the improvement is rather small regarding the FPS.
But the frame capture & correction could still be parallelized and the main process is no longer blocked for 1-2s during the algorithm, so the balancing, web API etc should also be smoother and more responsive, so it was definitely worth it. And it should also be slightly faster when the video stream is not open since the frames don't have to be shared between the processes in that case.

To further improve the FPS, I will try to adjust the HoG detection parameters to perform better. But to keep things separate, I'll do it in a further PR.