### PR TITLE
Build optimized OpenCv

### DIFF
--- a/backend/install.sh
+++ b/backend/install.sh
@@ -19,4 +19,4 @@ else
 fi
 
 # install numpy
-sudo apt-get install python3-numpy
+sudo apt-get install -y python3-numpy

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -17,6 +17,3 @@ if [[ "$1" == "--pip" ]]; then
 else
   poetry install
 fi
-
-# install numpy
-sudo apt-get install -y python3-numpy

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -17,3 +17,6 @@ if [[ "$1" == "--pip" ]]; then
 else
   poetry install
 fi
+
+# install numpy
+sudo apt-get install python3-numpy

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -156,25 +156,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "numpy"
-version = "1.20.1"
-description = "NumPy is the fundamental package for array computing with Python."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
-name = "opencv-python-headless"
-version = "4.5.1.48"
-description = "Wrapper package for OpenCV python bindings."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-numpy = ">=1.19.3"
-
-[[package]]
 name = "protobuf"
 version = "3.15.6"
 description = "Protocol Buffers"
@@ -333,7 +314,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5bbecdb60af8ea5d12cfb344c871bbf0379276ae956e61dd87118d6b95080745"
+content-hash = "faa15a4292befea2d9d00f7c72a25d94ac46e8d15366d66804b939334ba7be0c"
 
 [metadata.files]
 aiohttp = [
@@ -485,59 +466,6 @@ multidict = [
     {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
     {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
     {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
-]
-numpy = [
-    {file = "numpy-1.20.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ae61f02b84a0211abb56462a3b6cd1e7ec39d466d3160eb4e1da8bf6717cdbeb"},
-    {file = "numpy-1.20.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:65410c7f4398a0047eea5cca9b74009ea61178efd78d1be9847fac1d6716ec1e"},
-    {file = "numpy-1.20.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2d7e27442599104ee08f4faed56bb87c55f8b10a5494ac2ead5c98a4b289e61f"},
-    {file = "numpy-1.20.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4ed8e96dc146e12c1c5cdd6fb9fd0757f2ba66048bf94c5126b7efebd12d0090"},
-    {file = "numpy-1.20.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ecb5b74c702358cdc21268ff4c37f7466357871f53a30e6f84c686952bef16a9"},
-    {file = "numpy-1.20.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b9410c0b6fed4a22554f072a86c361e417f0258838957b78bd063bde2c7f841f"},
-    {file = "numpy-1.20.1-cp37-cp37m-win32.whl", hash = "sha256:3d3087e24e354c18fb35c454026af3ed8997cfd4997765266897c68d724e4845"},
-    {file = "numpy-1.20.1-cp37-cp37m-win_amd64.whl", hash = "sha256:89f937b13b8dd17b0099c7c2e22066883c86ca1575a975f754babc8fbf8d69a9"},
-    {file = "numpy-1.20.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a1d7995d1023335e67fb070b2fae6f5968f5be3802b15ad6d79d81ecaa014fe0"},
-    {file = "numpy-1.20.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:60759ab15c94dd0e1ed88241fd4fa3312db4e91d2c8f5a2d4cf3863fad83d65b"},
-    {file = "numpy-1.20.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:125a0e10ddd99a874fd357bfa1b636cd58deb78ba4a30b5ddb09f645c3512e04"},
-    {file = "numpy-1.20.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c26287dfc888cf1e65181f39ea75e11f42ffc4f4529e5bd19add57ad458996e2"},
-    {file = "numpy-1.20.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:7199109fa46277be503393be9250b983f325880766f847885607d9b13848f257"},
-    {file = "numpy-1.20.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:72251e43ac426ff98ea802a931922c79b8d7596480300eb9f1b1e45e0543571e"},
-    {file = "numpy-1.20.1-cp38-cp38-win32.whl", hash = "sha256:c91ec9569facd4757ade0888371eced2ecf49e7982ce5634cc2cf4e7331a4b14"},
-    {file = "numpy-1.20.1-cp38-cp38-win_amd64.whl", hash = "sha256:13adf545732bb23a796914fe5f891a12bd74cf3d2986eed7b7eba2941eea1590"},
-    {file = "numpy-1.20.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:104f5e90b143dbf298361a99ac1af4cf59131218a045ebf4ee5990b83cff5fab"},
-    {file = "numpy-1.20.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:89e5336f2bec0c726ac7e7cdae181b325a9c0ee24e604704ed830d241c5e47ff"},
-    {file = "numpy-1.20.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:032be656d89bbf786d743fee11d01ef318b0781281241997558fa7950028dd29"},
-    {file = "numpy-1.20.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:66b467adfcf628f66ea4ac6430ded0614f5cc06ba530d09571ea404789064adc"},
-    {file = "numpy-1.20.1-cp39-cp39-win32.whl", hash = "sha256:12e4ba5c6420917571f1a5becc9338abbde71dd811ce40b37ba62dec7b39af6d"},
-    {file = "numpy-1.20.1-cp39-cp39-win_amd64.whl", hash = "sha256:9c94cab5054bad82a70b2e77741271790304651d584e2cdfe2041488e753863b"},
-    {file = "numpy-1.20.1-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:9eb551d122fadca7774b97db8a112b77231dcccda8e91a5bc99e79890797175e"},
-    {file = "numpy-1.20.1.zip", hash = "sha256:3bc63486a870294683980d76ec1e3efc786295ae00128f9ea38e2c6e74d5a60a"},
-]
-opencv-python-headless = [
-    {file = "opencv-python-headless-4.5.1.48.tar.gz", hash = "sha256:d16825755e7b5a6d8737f93e116670229e1510199e0af9213004e187ae0dbcc5"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:f2011ecb3980bbed283d17d43e0f1221bac88c0cac1a6fb59a056544de2df2f7"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:777fb596e04331f73ef5b0c1faa4d33348f29ca58216d9286355c16f5489c939"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:924aa4c34ead0b817309f42291dc526b2a7755476afe3009d1e275fc3090d92d"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:0e02809db2968e54f3c23340be6ff9a1428b3f03f5dca7cd5aceda66e319ce86"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-win32.whl", hash = "sha256:522f12dd994e064a30562adfd63b9439099bd7c80819f5261c37ebe593283c9e"},
-    {file = "opencv_python_headless-4.5.1.48-cp36-cp36m-win_amd64.whl", hash = "sha256:e3027e0d1b71b68b5cfe1ea9c627e323dff71112c854ba19805258d8fc6c630e"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:f5e40a06116460ef2fd2d1c24be3b65f8bfb5fcdfe433f3fc01bcb4c2eb485bf"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ba2f0bd46e9534f29969e39f7895cbea9764173102b0c04b7818b8a9910d66e4"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:f7f8e4f7c63c8e95eb210f4cba88d0069a0a964d6335d7a35b07f0d0baa13558"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:aa562c520f46283423ba8fac29099458e42deab697a9abd0491622e421c5c454"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-win32.whl", hash = "sha256:657cdd9fbbbbb7e898ae3d9b0649b367d0e440d429c714104d069c5612d578bb"},
-    {file = "opencv_python_headless-4.5.1.48-cp37-cp37m-win_amd64.whl", hash = "sha256:fe02a943b1a28b505e954fbce24e867119a3eb4351f93adad55c6cfe81a70484"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:526b9e19cf6300f0891d8f427eac1048091912332bb781eb4957a4994bfbe608"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5f0c7d34fa9953706c2a1a6d2760a91dc5a68cab3df16af61609894c6c8586f1"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:1f7c14f5d4e5af4dc4669fc6b4a983b36072a934c439ac11266b930496da8255"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:7c75680ffdf32d7044415a215d1fc60dbec14a7f2f0b59a85f0f74ef5efcb6ad"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-win32.whl", hash = "sha256:2560dcf3c1158226b066302f777bfe0f65282410b8d90871dd872306c967d1f1"},
-    {file = "opencv_python_headless-4.5.1.48-cp38-cp38-win_amd64.whl", hash = "sha256:9aa04a491c534531029fbac61da961fae0bf4abb1786eed9c91befde4ca7bd81"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:96d1da6ad061d8f3509668d398d14dd8265e529d6407f87eb26e7f4ddf043cc0"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:243aea91cc1e36a47c46da4cc408071af39444a48df1fe1539ea8d7990500fd2"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2e6a9a88617a0ef7219cff24ba78a58416670a77e6ac63975f9009af3319ab63"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:372149d007e20bf556b7687591d22b58b56b3c225f492da051d81587e5dc7411"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-win32.whl", hash = "sha256:65c9ea57be5ebcaed009b3fee14fe59f3b6aa1e573fe08c5039ff057ad593c53"},
-    {file = "opencv_python_headless-4.5.1.48-cp39-cp39-win_amd64.whl", hash = "sha256:a322d4df14c3a5f19701a023b3da91e9b8af8653b0d2ee0c50b0b341212f7343"},
 ]
 protobuf = [
     {file = "protobuf-3.15.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1771ef20e88759c4d81db213e89b7a1fc53937968e12af6603c658ee4bcbfa38"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,8 +6,6 @@ authors = ["Marc Berchtold <me@echolot.io>", "Cyril Wanner <info@cyr.li>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-numpy = "^1.20.1"
-opencv-python-headless = "4.5.1.48"
 python-socketio = "^5.0.4"
 aiohttp = "^3.7.4"
 protobuf = "^3.15.6"

--- a/documents/raspberry-pi-setup.md
+++ b/documents/raspberry-pi-setup.md
@@ -18,6 +18,12 @@ This document provides a guide to set up a Raspberry Pi with the Real Stereo App
 1. Run the install script by executing: `curl -sSL https://raw.githubusercontent.com/ItsEcholot/real-stereo-extended/main/scripts/pi-install.sh | bash -`
 1. When the installation has finished, the Raspberry Pi will restart and is ready to use. The real stereo application will start automatically and listens on port `8080`.
 
+### Optimizing OpenCV
+
+It is possible to build opencv optimized for a raspberry pi which results in up to 200% better performance.
+To do so, simply run `/home/pi/real-stereo-extended/scripts/pi-optimize-opencv.sh`.
+The whole process can take up to 2 hours.
+
 ### Wifi setup
 
 Until the feature has been implement into real stereo that the web interface provides a way to connect to a wifi network, you have to do it manually.

--- a/scripts/config/real-stereo.service
+++ b/scripts/config/real-stereo.service
@@ -11,7 +11,7 @@ StartLimitInterval=120
 User=pi
 Group=pi
 WorkingDirectory=/home/pi/real-stereo-extended/backend/
-ExecStart=/usr/bin/env python /home/pi/real-stereo-extended/backend/src
+ExecStart=/usr/bin/env LD_PRELOAD=/usr/lib/gcc/arm-linux-gnueabihf/8/libatomic.so python /home/pi/real-stereo-extended/backend/src
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -58,6 +58,7 @@ else
   (cd "$PROJECT_DIR" && git pull)
 fi
 bash "$PROJECT_DIR/backend/install.sh" --pip
+pip3 install opencv-python-headless
 (cd "$PROJECT_DIR/frontend" && yarn install && yarn run build)
 if [[ ! -f "/etc/systemd/system/real-stereo.service" ]]; then
   sudo ln -s "$PROJECT_DIR/scripts/config/real-stereo.service" /etc/systemd/system/real-stereo.service

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -35,6 +35,7 @@ sudo apt-get install --yes \
   python3-apt \
   python3-dev \
   python3-distutils \
+  python3-numpy \
   python3-pip \
   python3-protobuf
 

--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -18,7 +18,7 @@ sudo /etc/init.d/dphys-swapfile start
 if [[ $(pip3 list | grep opencv) ]]; then
   pip3 uninstall -y opencv-python-headless
   pip3 uninstall -y numpy || true # fails if installed with apt-get, which is what we want so it can be ignored
-  apt-get install -y python3-numpy
+  sudo apt-get install -y python3-numpy
 fi
 
 # clone TBB

--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# stopping real-stereo
+sudo service real-stereo stop
+
 # install dependencies
 sudo apt-get install -y build-essential cmake pkg-config checkinstall \
   libjpeg-dev libpng-dev libtiff-dev libprotobuf-dev protobuf-compiler
@@ -11,8 +14,11 @@ sudo sed -i 's/CONF_SWAPSIZE=100/CONF_SWAPSIZE=2048/g' /etc/dphys-swapfile
 sudo /etc/init.d/dphys-swapfile stop
 sudo /etc/init.d/dphys-swapfile start
 
-# todo: uninstall opencv-python-headless if installed using pip
-# todo: add opencv-python-headless to pi-install.sh
+# remove opencv previously installed through pip
+if [[ $(pip3 list | grep opencv) ]]; then
+  pip3 uninstall opencv-python-headless
+  pip3 uninstall numpy || true # fails if installed with apt-get, which is what we want so it can be ignored
+fi
 
 # clone TBB
 git clone --depth 1 https://github.com/oneapi-src/oneTBB.git /home/pi/tbb
@@ -56,3 +62,5 @@ sudo sed -i 's/CONF_SWAPSIZE=2048/CONF_SWAPSIZE=100/g' /etc/dphys-swapfile
 sudo /etc/init.d/dphys-swapfile stop
 sudo /etc/init.d/dphys-swapfile start
 
+# start real-stereo again
+sudo service real-stereo start

--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -18,6 +18,7 @@ sudo /etc/init.d/dphys-swapfile start
 if [[ $(pip3 list | grep opencv) ]]; then
   pip3 uninstall -y opencv-python-headless
   pip3 uninstall -y numpy || true # fails if installed with apt-get, which is what we want so it can be ignored
+  apt-get install -y python3-numpy
 fi
 
 # clone TBB

--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+# install dependencies
+sudo apt-get install -y build-essential cmake pkg-config checkinstall \
+  libjpeg-dev libpng-dev libtiff-dev libprotobuf-dev protobuf-compiler
+
+# enlarge swap
+sudo sed -i 's/CONF_SWAPSIZE=100/CONF_SWAPSIZE=2048/g' /etc/dphys-swapfile
+sudo /etc/init.d/dphys-swapfile stop
+sudo /etc/init.d/dphys-swapfile start
+
+# todo: uninstall opencv-python-headless if installed using pip
+# todo: add opencv-python-headless to pi-install.sh
+
+# clone TBB
+git clone --depth 1 https://github.com/oneapi-src/oneTBB.git /home/pi/tbb
+cd /home/pi/tbb
+CXXFLAGS="-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0" cmake -DTBB_TEST:BOOL=OFF --configure .
+CXXFLAGS="-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0" cmake --build .
+sudo cmake -DCOMPONENT=runtime -P cmake_install.cmake
+sudo cmake -DCOMPONENT=devel -P cmake_install.cmake
+
+# clone opencv
+git clone --depth 1 https://github.com/opencv/opencv.git /home/pi/opencv
+mkdir /home/pi/opencv/build
+cd /home/pi/opencv/build
+
+# compile opencv
+export CFLAGS="-mcpu=cortex-a53 -mfloat-abi=hard -mfpu=neon-fp-armv8 -mneon-for-64bits -DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0"
+export CXXFLAGS="-mcpu=cortex-a53 -mfloat-abi=hard -mfpu=neon-fp-armv8 -mneon-for-64bits -DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0"
+
+cmake -D CMAKE_BUILD_TYPE=RELEASE \
+-D CMAKE_INSTALL_PREFIX=/usr/local \
+-D PYTHON_DEFAULT_EXECUTABLE=$(which python3) \
+-D BUILD_opencv_python2=OFF \
+-D BUILD_opencv_python3=ON \
+-D WITH_TBB=ON \
+-D WITH_OPENMP=ON \
+-D ENABLE_NEON=ON \
+-D ENABLE_VFPV3=ON \
+-D BUILD_TESTS=OFF \
+-D INSTALL_PYTHON_EXAMPLES=OFF \
+-D OPENCV_ENABLE_NONFREE=OFF \
+-D OPENCV_EXTRA_EXE_LINKER_FLAGS=-latomic \
+-D BUILD_PERF_TESTS=OFF \
+-D BUILD_EXAMPLES=OFF ..
+
+make
+sudo make install
+sudo ldconfig
+
+# shrink swap again
+sudo sed -i 's/CONF_SWAPSIZE=2048/CONF_SWAPSIZE=100/g' /etc/dphys-swapfile
+sudo /etc/init.d/dphys-swapfile stop
+sudo /etc/init.d/dphys-swapfile start
+

--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -16,8 +16,8 @@ sudo /etc/init.d/dphys-swapfile start
 
 # remove opencv previously installed through pip
 if [[ $(pip3 list | grep opencv) ]]; then
-  pip3 uninstall opencv-python-headless
-  pip3 uninstall numpy || true # fails if installed with apt-get, which is what we want so it can be ignored
+  pip3 uninstall -y opencv-python-headless
+  pip3 uninstall -y numpy || true # fails if installed with apt-get, which is what we want so it can be ignored
 fi
 
 # clone TBB

--- a/scripts/pi-run-backend.sh
+++ b/scripts/pi-run-backend.sh
@@ -15,4 +15,4 @@ fi
 ssh "pi@$IP" 'if [[ $(sudo systemctl status real-stereo) ]]; then sudo systemctl stop real-stereo; fi'
 
 # start real-stereo interactively
-ssh -o ServerAliveInterval=240 -t "pi@$IP" "cd ~/real-stereo-extended/backend && python src ${@:2}"
+ssh -o ServerAliveInterval=240 -t "pi@$IP" "cd ~/real-stereo-extended/backend && LD_PRELOAD=/usr/lib/gcc/arm-linux-gnueabihf/8/libatomic.so python src ${@:2}"

--- a/scripts/pi-update-scripts.sh
+++ b/scripts/pi-update-scripts.sh
@@ -9,3 +9,4 @@ if [[ -z $IP ]]; then
 fi
 
 rsync --recursive --links --times --perms --devices --specials --delete --compress --verbose "$DIR/../scripts/" "pi@$IP:/home/pi/real-stereo-extended/scripts"
+ssh "pi@$IP" 'sudo systemctl daemon-reload'

--- a/scripts/pi-update-scripts.sh
+++ b/scripts/pi-update-scripts.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+IP="$1"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+if [[ -z $IP ]]; then
+  echo "Usage: $0 <ip-address>"
+  exit 1
+fi
+
+rsync --recursive --links --times --perms --devices --specials --delete --compress --verbose "$DIR/../scripts/" "pi@$IP:/home/pi/real-stereo-extended/scripts"


### PR DESCRIPTION
This provides an additional and optional script to build opencv on the raspberry pi. The default installation script will not run it as it takes ~80 minutes. So, at least for now, it has to be executed manually.
Depending on the algorithms used, the performance is up to 2 times better. For HoG, there isn't much of an improvement, but YOLO runs now at 2fps instead of 1fps.

Before running the script, make sure the backend & scripts directories are up-to-date by running:
* `./scripts/pi-update-backend.sh <IP>`
* `./scripts/pi-update-scripts.sh <IP>`

Then, connect to the pi using ssh and run:
`/home/pi/real-stereo-extended/scripts/pi-optimize-opencv.sh`