### PR TITLE
Ignore ssl certificate errors in chrome

### DIFF
--- a/backend/install.sh
+++ b/backend/install.sh
@@ -16,4 +16,7 @@ if [[ "$1" == "--pip" ]]; then
   pip3 install "picamera[array]"
 else
   poetry install
+
+  # manually install numpy since it is moved to apt-get for better opencv performance
+  pip3 install numpy
 fi


### PR DESCRIPTION
When visiting the page with Chrome (android & desktop), the console gets spammed with SSL errors, making debugging messages hard to read. This change simply suppresses these errors, which is the only workaround according to other Github issues.

Also, the error that vscode cannot resolve numpy anymore should be fixed (it was moved from poetry to apt-get during the opencv performance optimizations).