### PR TITLE
Calibration show previous points

### DIFF
--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -172,6 +172,7 @@ type RoomCalibrationPoint = {
   coordinateX: number;
   coordinateY: number;
   measuredVolume: number;
+  speaker_id: string;
 }
 
 type RoomCalibrationResponse = {

--- a/frontend/src/components/Calibration/index.tsx
+++ b/frontend/src/components/Calibration/index.tsx
@@ -120,6 +120,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
                 <Steps progressDot direction="vertical" size="small" current={calibrationStep}>
                   <Steps.Step title="Position yourself" description={<>
                     <span>When you're at the desired location press</span>
+                    <br/>
                     <Button type="default" disabled={calibrationStep !== 0} loading={calibrationNextPointing} onClick={onNextPoint}>Next Position</Button>
                   </>} />
                   {roomSpeakers.map((speaker, index) => <Steps.Step key={speaker.id} title={`Measuring ${speaker.name}`} description={<>

--- a/frontend/src/components/Calibration/index.tsx
+++ b/frontend/src/components/Calibration/index.tsx
@@ -48,7 +48,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
       setCalibrationStep(0);
     }
   }, [setCalibrationStep, roomCalibration]);
-
+  
   useEffect(() => {
     if (!roomCalibration?.calibrating) return;
     prepareCalibration();
@@ -104,7 +104,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
       ))}
       {!roomCalibration?.calibrating ?
         <Button type="primary" loading={calibrationStarting} icon={<RadarChartOutlined />} onClick={onStartCalibration}>
-          Start calibration
+          {roomCalibration?.previousPoints && roomCalibration.previousPoints.length > 0 ? 'Restart calibration' : 'Start calibration'}
         </Button> :
         <>
           <Space direction="vertical" className={styles.space}>

--- a/frontend/src/pages/EditRoom/index.tsx
+++ b/frontend/src/pages/EditRoom/index.tsx
@@ -129,17 +129,17 @@ const EditRoomPage: FunctionComponent<EditRoomPageProps> = ({
       </Form> : <Row justify="center"><Spin /></Row>}
       <Divider />
       <p>
-        Place the two cameras in a ~90° angle to each other.
+          Place the two cameras in a ~90° angle to each other.
           <br />
           Make sure that it is as quiet as possible inside the room.
           <br />
-          After starting the calibration, move yourself with the microphone to the specified position.
+          You can add as many calibration positions as you want.
           <br />
-          Stand still until you are told to move to the next position.
+          After selecting a position by clicking on "Next Position" stand still until all the measurements are done.
           <br />
-          When the four corner positions are set up, you can add as many additional positions between those corner positions as you like.
+          After that you can confirm or repeat the last position.
           <br />
-          When all positions are calibrated, exit the configuration by pressing the save button.
+          When all positions are calibrated, exit the configuration by pressing "Finish calibration".
         </p>
       {roomId && currentRoomSpeakers?.length ? 
         <Calibration roomId={roomId} roomSpeakers={currentRoomSpeakers}/> :

--- a/frontend/src/services/audioMeter.tsx
+++ b/frontend/src/services/audioMeter.tsx
@@ -1,4 +1,5 @@
 import { RefObject, useEffect, useState } from 'react';
+import { drawSpectrumAnalyzer } from './canvasDrawTools';
 
 const fftWindowSize = 512;
 const aWeighting = [
@@ -79,17 +80,6 @@ const calculateLoudness = (energies: Uint32Array): number => {
     energies[i] = energies[i] * Math.pow(10, aWeighting[i] / 10.0);
   }
   return sum / 255;
-}
-
-const drawSpectrumAnalyzer = (context: CanvasRenderingContext2D, fftData: Uint8Array, frequencyPerArrayItem: number) => {
-  context.beginPath();
-  fftData.forEach((value, index) => {
-    context.lineTo(index * 2, value);
-    if ((frequencyPerArrayItem * index) % 1000 === 0) {
-      context.fillText(`${Math.round(frequencyPerArrayItem * index)}`, index * 2, 250)
-    }
-  });
-  context.stroke();
 }
 
 export const prepareAudioMeter = async (): Promise<void> => {

--- a/frontend/src/services/canvasDrawTools.tsx
+++ b/frontend/src/services/canvasDrawTools.tsx
@@ -2,6 +2,17 @@ import { RoomCalibrationPoint } from "./roomCalibration";
 
 export const maxCord = 640;
 
+export const drawSpectrumAnalyzer = (context: CanvasRenderingContext2D, fftData: Uint8Array, frequencyPerArrayItem: number) => {
+  context.beginPath();
+  fftData.forEach((value, index) => {
+    context.lineTo(index * 2, value);
+    if ((frequencyPerArrayItem * index) % 1000 === 0) {
+      context.fillText(`${Math.round(frequencyPerArrayItem * index)}`, index * 2, 250)
+    }
+  });
+  context.stroke();
+}
+
 export const mapCoordinate = (cord: number, canvasSize: number): number => {
   // Remove aliasing using +0.5
   return Math.round((cord / maxCord) * canvasSize) + 0.5;

--- a/frontend/src/services/canvasDrawTools.tsx
+++ b/frontend/src/services/canvasDrawTools.tsx
@@ -1,0 +1,91 @@
+import { RoomCalibrationPoint } from "./roomCalibration";
+
+export const maxCord = 640;
+
+export const mapCoordinate = (cord: number, canvasSize: number): number => {
+  // Remove aliasing using +0.5
+  return Math.round((cord / maxCord) * canvasSize) + 0.5;
+}
+
+export const getRandomHexColourString = (index: number): string => {
+  const maxAmountOfColours = 16;
+  const hueDelta = Math.trunc(360 / maxAmountOfColours);
+  const h = (index % maxAmountOfColours) * hueDelta;
+  let s = 100;
+  let l = 40;
+
+  // convert hsl to rgb from: https://css-tricks.com/converting-color-spaces-in-javascript/
+  s /= 100;
+  l /= 100;
+
+  let c = (1 - Math.abs(2 * l - 1)) * s,
+    x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+    m = l - c / 2,
+    r = 0,
+    g = 0,
+    b = 0;
+
+  if (0 <= h && h < 60) {
+    r = c; g = x; b = 0;
+  } else if (60 <= h && h < 120) {
+    r = x; g = c; b = 0;
+  } else if (120 <= h && h < 180) {
+    r = 0; g = c; b = x;
+  } else if (180 <= h && h < 240) {
+    r = 0; g = x; b = c;
+  } else if (240 <= h && h < 300) {
+    r = x; g = 0; b = c;
+  } else if (300 <= h && h < 360) {
+    r = c; g = 0; b = x;
+  }
+  // Having obtained RGB, convert channels to hex
+  let rString = Math.round((r + m) * 255).toString(16);
+  let gString = Math.round((g + m) * 255).toString(16);
+  let bString = Math.round((b + m) * 255).toString(16);
+
+  // Prepend 0s, if necessary
+  if (rString.length === 1)
+    rString = "0" + r;
+  if (gString.length === 1)
+    gString = "0" + g;
+  if (bString.length === 1)
+    bString = "0" + b;
+
+  return "#" + rString + gString + bString;
+}
+
+export const drawCurrentPosition = (context: CanvasRenderingContext2D, canvasSize: number, x: number, y: number) => {
+  const crosshairRadius = 0.03 * canvasSize;
+  context.strokeStyle = '#ff0000';
+  context.lineWidth = 0.01 * canvasSize;
+  context.beginPath();
+  context.moveTo(x - crosshairRadius, y);
+  context.lineTo(x + crosshairRadius, y);
+  context.moveTo(x, y - crosshairRadius);
+  context.lineTo(x, y + crosshairRadius);
+  context.stroke();
+}
+
+export const drawPoints = (context: CanvasRenderingContext2D, canvasSize: number, previousPoints: RoomCalibrationPoint[], fillStyle: string) => {
+  const pointRadius = 0.05 * canvasSize;
+  context.font = `${0.08 * canvasSize}px sans-serif`;
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.beginPath();
+  const points = previousPoints.filter((point, index, arr) => {
+    return arr.findIndex(x => (x.coordinateX === point.coordinateX && x.coordinateY === point.coordinateY)) === index
+  });
+
+  // draw all points
+  points.forEach(point => {
+    context.fillStyle = fillStyle;
+    context.arc(mapCoordinate(point.coordinateX, canvasSize), mapCoordinate(point.coordinateY, canvasSize), pointRadius, 0, 2 * Math.PI);
+    context.fill();
+  });
+
+  // draw labels over points
+  points.forEach((point, index) => {
+    context.fillStyle = '#ffffff';
+    context.fillText(`${index+1}`, mapCoordinate(point.coordinateX, canvasSize), mapCoordinate(point.coordinateY, canvasSize));
+  });
+}

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -99,7 +99,7 @@ const getRandomHexColourString = (index: number): string => {
 
 const drawCurrentPosition = (context: CanvasRenderingContext2D, x: number, y: number) => {
   const crosshairRadius = 3;
-  context.strokeStyle = getRandomHexColourString(x % 32);//'#ff0000';
+  context.strokeStyle = '#ff0000';
   context.beginPath();
   context.moveTo(x - crosshairRadius, y);
   context.lineTo(x + crosshairRadius, y);

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -50,9 +50,56 @@ const mapCoordinate = (cord: number): number => {
   return Math.round((cord / maxCord) * canvasCordSize) + 0.5;
 }
 
+const getRandomHexColourString = (index: number): string => {
+  const maxAmountOfColours = 16;
+  const hueDelta = Math.trunc(360 / maxAmountOfColours);
+  const h = (index % maxAmountOfColours) * hueDelta;
+  let s = 100;
+  let l = 40;
+
+  // convert hsl to rgb from: https://css-tricks.com/converting-color-spaces-in-javascript/
+  s /= 100;
+  l /= 100;
+
+  let c = (1 - Math.abs(2 * l - 1)) * s,
+      x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+      m = l - c/2,
+      r = 0,
+      g = 0, 
+      b = 0; 
+
+    if (0 <= h && h < 60) {
+      r = c; g = x; b = 0;
+    } else if (60 <= h && h < 120) {
+      r = x; g = c; b = 0;
+    } else if (120 <= h && h < 180) {
+      r = 0; g = c; b = x;
+    } else if (180 <= h && h < 240) {
+      r = 0; g = x; b = c;
+    } else if (240 <= h && h < 300) {
+      r = x; g = 0; b = c;
+    } else if (300 <= h && h < 360) {
+      r = c; g = 0; b = x;
+    }
+    // Having obtained RGB, convert channels to hex
+    let rString = Math.round((r + m) * 255).toString(16);
+    let gString = Math.round((g + m) * 255).toString(16);
+    let bString = Math.round((b + m) * 255).toString(16);
+
+    // Prepend 0s, if necessary
+    if (rString.length === 1)
+      rString = "0" + r;
+    if (gString.length === 1)
+      gString = "0" + g;
+    if (bString.length === 1)
+      bString = "0" + b;
+
+    return "#" + rString + gString + bString;
+}
+
 const drawCurrentPosition = (context: CanvasRenderingContext2D, x: number, y: number) => {
   const crosshairRadius = 3;
-  context.strokeStyle = '#ff0000';
+  context.strokeStyle = getRandomHexColourString(x % 32);//'#ff0000';
   context.beginPath();
   context.moveTo(x - crosshairRadius, y);
   context.lineTo(x + crosshairRadius, y);

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -109,13 +109,27 @@ const drawCurrentPosition = (context: CanvasRenderingContext2D, x: number, y: nu
 }
 
 const drawPoints = (context: CanvasRenderingContext2D, previousPoints: RoomCalibrationPoint[], fillStyle: string) => {
-  const pointRadius = 2;
-  context.fillStyle = fillStyle;
+  const pointRadius = 5;
+  context.font = '8px sans-serif';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
   context.beginPath();
-  for (const point of previousPoints) {
+  const points = previousPoints.filter((point, index, arr) => {
+    return arr.findIndex(x => (x.coordinateX === point.coordinateX && x.coordinateY === point.coordinateY)) === index
+  });
+
+  // draw all points
+  points.forEach(point => {
+    context.fillStyle = fillStyle;
     context.arc(mapCoordinate(point.coordinateX), mapCoordinate(point.coordinateY), pointRadius, 0, 2 * Math.PI);
     context.fill();
-  }
+  });
+
+  // draw labels over points
+  points.forEach((point, index) => {
+    context.fillStyle = '#ffffff';
+    context.fillText(`${index+1}`, mapCoordinate(point.coordinateX), mapCoordinate(point.coordinateY));
+  });
 }
 
 export const useRoomCalibration = (roomId: number, calibrationMapCanvasRef: RefObject<HTMLCanvasElement> | null = null) => {
@@ -131,7 +145,6 @@ export const useRoomCalibration = (roomId: number, calibrationMapCanvasRef: RefO
   const setRoomCalibrationForRoom = useCallback((roomCalibration: RoomCalibrationResponse) => {
     if (roomCalibration.room.id === roomId) {
       setRoomCalibration(roomCalibration);
-      console.dir(roomCalibration);
 
       const context = calibrationMapCanvasRef?.current?.getContext("2d");
       if (context) {


### PR DESCRIPTION
This displays the calibration points on the map canvas. It also adds the colouring function which will be used in the future (after the interpolation is implemented, I'm guessing @cyrilwanner, you're currently working on it?), to draw the same volume interpolation debug overlay as we had in real-stereo v1.