### PR TITLE
Implement speaker balancing

### DIFF
--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -22,8 +22,8 @@ async def main():
 
     if config.type == NodeType.MASTER or '--master' in argv:
         cluster_slave = ClusterSlave(config, tracking)
-        cluster_master = ClusterMaster(config, cluster_slave)
         balancing = BalancingManager(config)
+        cluster_master = ClusterMaster(config, cluster_slave, balancing)
         api = ApiManager(config, tracking, cluster_master, balancing)
 
         await asyncio.gather(

--- a/backend/src/api/controllers/balances.py
+++ b/backend/src/api/controllers/balances.py
@@ -1,0 +1,40 @@
+"""Controller for the /balances namespace."""
+
+from typing import List
+from socketio import AsyncNamespace
+from models.speaker import Speaker
+
+
+class BalancesController(AsyncNamespace):
+    """Controller for the /balances namespace."""
+
+    def __init__(self):
+        super().__init__(namespace='/balances')
+        self.connections = 0
+
+    def on_connect(self, _, __) -> None:
+        """On client connect."""
+        self.connections += 1
+
+    def on_disconnect(self, _) -> None:
+        """On client disconnect."""
+        self.connections -= 1
+
+    async def send_balances(self, speakers: List[Speaker], volumes: List[int]) -> None:
+        """Sends the current balances to all clients.
+
+        :param List[Speaker] speakers: All speakers
+        :param List[int] volumes: Volumes for the speakers
+        """
+        if self.connections < 1:
+            return
+
+        balances = []
+
+        for index, speaker in enumerate(speakers):
+            balances.append({
+                'volume': volumes[index],
+                'speaker': speaker.to_json(recursive=True)
+            })
+
+        await self.emit('get', balances)

--- a/backend/src/api/controllers/nodes.py
+++ b/backend/src/api/controllers/nodes.py
@@ -44,6 +44,9 @@ class NodesController(AsyncNamespace):
 
         validate.string(name, label='Name', min_value=1, max_value=50)
 
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+
         if detector is not None:
             validate.string(detector, label='Detection Algorithm', min_value=3, max_value=8)
 
@@ -116,11 +119,14 @@ class NodesController(AsyncNamespace):
         """
         ack = Acknowledgment()
 
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+
         node = self.config.node_repository.get_node(node_id)
         if node is None:
             ack.add_error('A node with this id does not exist')
 
-        if node.room is not None:
+        if ack.successful and node.room is not None:
             node.room.nodes.remove(node)
             node.room = None
 

--- a/backend/src/api/controllers/room_calibration.py
+++ b/backend/src/api/controllers/room_calibration.py
@@ -4,7 +4,6 @@ from socketio import AsyncNamespace
 from config import Config
 from models.acknowledgment import Acknowledgment
 from models.room import Room
-from models.speaker import Speaker
 from models.room_calibration_point import RoomCalibrationPoint
 from api.validate import Validate
 from balancing.sonos import Sonos

--- a/backend/src/api/controllers/rooms.py
+++ b/backend/src/api/controllers/rooms.py
@@ -44,6 +44,9 @@ class RoomsController(AsyncNamespace):
 
         validate.string(name, label='Name', min_value=1, max_value=50)
 
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+
         if people_group is not None:
             validate.string(people_group, label='Handle multiple people', min_value=5, max_value=10)
 
@@ -126,7 +129,9 @@ class RoomsController(AsyncNamespace):
         """
         ack = Acknowledgment()
 
-        if await self.config.room_repository.remove_room(room_id) is False:
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+        elif await self.config.room_repository.remove_room(room_id) is False:
             ack.add_error('A room with this id does not exist')
 
         return ack.to_json()

--- a/backend/src/api/controllers/speakers.py
+++ b/backend/src/api/controllers/speakers.py
@@ -41,6 +41,9 @@ class SpeakersController(AsyncNamespace):
 
         validate.string(name, label='Name', min_value=1, max_value=50)
 
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+
         if data.get('room') is None or isinstance(data.get('room'), dict) is False:
             ack.add_error('Room id must not be empty')
         elif validate.integer(data.get('room').get('id'), label='Room id', min_value=1):
@@ -101,7 +104,9 @@ class SpeakersController(AsyncNamespace):
         """
         ack = Acknowledgment()
 
-        if await self.config.speaker_repository.remove_speaker(speaker_id) is False:
+        if self.config.balance:
+            ack.add_error('No configuration changes can be made when balancing is active')
+        elif await self.config.speaker_repository.remove_speaker(speaker_id) is False:
             ack.add_error('A speaker with this id does not exist')
 
         return ack.to_json()

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -230,9 +230,10 @@ class ApiManager:
         def ignore_ssl_error(loop, context):
             if context.get('message') in messages:
                 exception = context.get('exception')
-                if isinstance(exception, ssl.SSLError) and \
-                        exception.reason == 'SSLV3_ALERT_CERTIFICATE_UNKNOWN':
-                    return
+                if isinstance(exception, ssl.SSLError):
+                    if exception.reason == 'SSLV3_ALERT_CERTIFICATE_UNKNOWN' or \
+                            exception.reason == 'KRB5_S_INIT':
+                        return
 
             if original_handler is not None:
                 original_handler(loop, context)

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -17,6 +17,7 @@ from .controllers.speakers import SpeakersController
 from .controllers.settings import SettingsController
 from .controllers.camera_calibration import CameraCalibrationController
 from .controllers.room_calibration import RoomCalibrationController
+from .controllers.balances import BalancesController
 from .ssl_generator import SSLGenerator
 
 # define path of the static frontend files
@@ -80,6 +81,9 @@ class ApiManager:
                                                                          balancing_manager, 'sonos', None),
                                                                      tracking_manager=tracking_manager,
                                                                      cluster_master=cluster_master))
+            balances_controller = BalancesController()
+            balancing_manager.balances_api_controller = balances_controller
+            self.server.register_namespace(balances_controller)
 
     async def get_index(self, _: web.Request) -> web.Response:
         """Returns the index.html on the / route.

--- a/backend/src/balancing/manager.py
+++ b/backend/src/balancing/manager.py
@@ -10,6 +10,9 @@ class BalancingManager:
     def __init__(self, config: Config):
         self.config = config
         self.sonos = Sonos(config)
+        self.previous_config_value = self.config.balance
+
+        self.config.setting_repository.register_listener(self.on_settings_changed)
 
     async def start_discovery(self) -> None:
         """Start the discovery loop"""
@@ -30,3 +33,32 @@ class BalancingManager:
         """Stop the control loop"""
         print('[Balancing] Stopping sonos control loop')
         self.sonos.stop_control_loop()
+
+    def start_balancing(self) -> None:
+        """Starts the speaker balancing"""
+        print('[Balancing] Starting balancing')
+
+        # get user set volume for all speakers
+        room_volumes = {}
+        for speaker in self.config.speakers:
+            if speaker.room.room_id not in room_volumes:
+                room_volumes[speaker.room.room_id] = []
+            room_volumes[speaker.room.room_id].append(self.sonos.sonos_adapter.get_volume(speaker))
+
+        # calculate average volume for each room
+        for room in self.config.rooms:
+            if room.room_id in room_volumes:
+                room.user_volume = sum(room_volumes[room.room_id]) / len(room_volumes[room.room_id])
+
+    def stop_balancing(self) -> None:
+        """Stopps the speaker balancing"""
+        print('[Balancing] Stopping balancing')
+
+    async def on_settings_changed(self) -> None:
+        """Update the balancing status when the settings have changed."""
+        if self.config.balance and self.config.balance != self.previous_config_value:
+            self.start_balancing()
+        elif not self.config.balance and self.config.balance != self.previous_config_value:
+            self.stop_balancing()
+
+        self.previous_config_value = self.config.balance

--- a/backend/src/balancing/volume_interpolation.py
+++ b/backend/src/balancing/volume_interpolation.py
@@ -1,0 +1,78 @@
+"""Interpolates volume for any specific point in a room."""
+from math import sqrt
+from models.speaker import Speaker
+
+
+POWER_PARAM = 1.5
+
+
+class VolumeInterpolation:
+    """Interpolates volume for any specific point in a room."""
+
+    def __init__(self, room):
+        self.room = room
+        self.target_volume = 0.0
+        self.calibration_points = []
+
+    def update(self) -> None:
+        """Update the interpolation configuration when the room has changed."""
+        self.target_volume = self.calculate_target_volume()
+        self.calibration_points = self.preprocess_calibration_points()
+
+    def preprocess_calibration_points(self) -> None:
+        """Preprocesses the calibration points."""
+        points = {}
+
+        for point in self.room.calibration_points:
+            if point.speaker.speaker_id not in points:
+                points[point.speaker.speaker_id] = []
+            points[point.speaker.speaker_id].append(point)
+
+        return points
+
+    def calculate_target_volume(self) -> float:
+        """Calculates the target volume for the room.
+        For interpolation, Shepard's method for scattered data is used.
+
+        :returns: Target volume
+        :rtype: float
+        """
+        target_volume = 0.0
+
+        for point in self.room.calibration_points:
+            if point.measured_volume > target_volume:
+                target_volume = point.measured_volume
+
+        return target_volume
+
+    def calculate_volume(self, coordinate_x: int, coordinate_y: int, speaker: Speaker) -> float:
+        """Calculates the volume for the given coordinate and speaker.
+
+        :param int coordinate_x: X coordinate
+        :param int coordinate_y: Y coordinate
+        :param models.Speaker speaker: Speaker
+        """
+        if speaker.speaker_id not in self.calibration_points:
+            print('Speaker with id {} is not calibrated for room {}'.format(
+                speaker.speaker_id, self.room.name))
+            return 0.0
+
+        total_weight = 0.0
+        total_volume = 0.0
+
+        for point in self.calibration_points[speaker.speaker_id]:
+            if point.coordinate_x == coordinate_x and point.coordinate_y == coordinate_y:
+                return point.measured_volume
+
+            # calculate distance of configuration point to the coordinate
+            distance_x = point.coordinate_x - coordinate_x
+            distance_y = point.coordinate_y - coordinate_y
+
+            # calculate weight of the configuration point based on the distance
+            weight = 1 / pow(sqrt(distance_x ** 2 + distance_y ** 2), POWER_PARAM)
+
+            # add the weighted volume
+            total_volume += weight * point.measured_volume
+            total_weight += weight
+
+        return total_volume / total_weight

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -37,6 +37,7 @@ class Config:
 
         # register repository change listeners
         self.room_repository.register_listener(self.store)
+        self.room_repository.register_listener(self.update_volume_interpolation)
         self.node_repository.register_listener(self.store)
         self.speaker_repository.register_listener(self.store)
 
@@ -86,3 +87,9 @@ class Config:
 
         with open(str(self.path), 'w') as file:
             json.dump(data, file, indent=4)
+
+    async def update_volume_interpolation(self) -> None:
+        """Updates the volume interpolation for all rooms."""
+        for room in self.rooms:
+            if room.volume_interpolation is not None:
+                room.volume_interpolation.update()

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -4,6 +4,7 @@ from typing import List
 import models.node
 from models.room_calibration_point import RoomCalibrationPoint
 from tracking.people_detector import DEFAULT_COORDINATE
+from balancing.volume_interpolation import VolumeInterpolation
 
 
 class Room:
@@ -32,6 +33,7 @@ class Room:
         self.calibration_point_freeze: bool = False
         self.people_group: str = people_group
         self.coordinates: List[int] = [DEFAULT_COORDINATE, DEFAULT_COORDINATE]
+        self.volume_interpolation = VolumeInterpolation(self)
 
     @staticmethod
     def from_json(data: dict):
@@ -50,7 +52,9 @@ class Room:
         :param config.Config config: Config instance
         """
         if data is not None:
-            self.calibration_points = list(map(lambda calibration_point: RoomCalibrationPoint.from_json(calibration_point, config), data))
+            self.calibration_points = list(
+                map(lambda calibration_point: RoomCalibrationPoint.from_json(calibration_point, config), data))
+            self.volume_interpolation.update()
 
     def to_json(self, recursive: bool = False) -> dict:
         """Creates a JSON serializable object.

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -33,6 +33,7 @@ class Room:
         self.calibration_point_freeze: bool = False
         self.people_group: str = people_group
         self.coordinates: List[int] = [DEFAULT_COORDINATE, DEFAULT_COORDINATE]
+        self.user_volume: float = 0.0
         self.volume_interpolation = VolumeInterpolation(self)
 
     @staticmethod

--- a/backend/src/protocol/master/master.py
+++ b/backend/src/protocol/master/master.py
@@ -198,7 +198,7 @@ class ClusterMaster(ClusterSocket):
         if node.room is not None and node.has_coordinate_type:
             coordinate_id = 0 if node.coordinate_type == 'x' else 1
             node.room.coordinates[coordinate_id] = message.positionUpdate.coordinate
-            self.balancing_manager.balance_room(node.room)
+            await self.balancing_manager.balance_room(node.room)
 
     async def on_camera_calibration_response(self, message: Wrapper, address: str) -> None:
         """Handle camera calibration response.

--- a/backend/src/protocol/master/master.py
+++ b/backend/src/protocol/master/master.py
@@ -4,6 +4,7 @@ from socket import socket, gethostname, AF_INET, SOCK_STREAM, MSG_DONTWAIT, MSG_
 import asyncio
 import asyncio_dgram
 from config import Config
+from balancing.manager import BalancingManager
 from ..socket import ClusterSocket
 from ..constants import PORT
 from ..cluster_pb2 import Wrapper
@@ -13,11 +14,12 @@ from .node_registry import NodeRegistry
 class ClusterMaster(ClusterSocket):
     """Master for the cluster protocol."""
 
-    def __init__(self, config: Config, direct_slave=None):
+    def __init__(self, config: Config, direct_slave, balancing_manager: BalancingManager):
         super().__init__()
         self.receive_socket = None
         self.config = config
         self.direct_slave = direct_slave
+        self.balancing_manager = balancing_manager
         self.node_registry = NodeRegistry(config, self)
         self.hostname = gethostname()
         self.slave_sockets = {}
@@ -196,8 +198,7 @@ class ClusterMaster(ClusterSocket):
         if node.room is not None and node.has_coordinate_type:
             coordinate_id = 0 if node.coordinate_type == 'x' else 1
             node.room.coordinates[coordinate_id] = message.positionUpdate.coordinate
-            print('Coordinate: x={}, y={}'.format(node.room.coordinates[0],
-                                                  node.room.coordinates[1]))
+            self.balancing_manager.balance_room(node.room)
 
     async def on_camera_calibration_response(self, message: Wrapper, address: str) -> None:
         """Handle camera calibration response.

--- a/backend/src/sonos/adapter.py
+++ b/backend/src/sonos/adapter.py
@@ -1,7 +1,6 @@
 """Defines methods to send commands to Sonos speakers"""
 from abc import ABC, abstractmethod
 from typing import Set
-from pathlib import Path
 from socket import gethostname, gethostbyname
 from models.speaker import Speaker
 
@@ -28,6 +27,14 @@ class SonosAdapter(ABC):
 
         :param models.speaker.Speaker speaker: Speaker to control
         :param int volume: Volume to set
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_volume(self, speaker: Speaker) -> int:
+        """Gets volume of passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker for which the volume gets requested
         """
         raise NotImplementedError()
 

--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -43,6 +43,14 @@ class SonosSocoAdapter(SonosAdapter):
         for index, slave in enumerate(soco_slaves):
             slave.volume = soco_slaves_volumes[index]
 
+    def get_volume(self, speaker: Speaker) -> int:
+        """Gets volume of passed Sonos speaker
+
+        :param models.speaker.Speaker speaker: Speaker for which the volume gets requested
+        """
+        soco_instance = soco.SoCo(speaker.ip_address)
+        return soco_instance.volume
+
     def ramp_to_volume(self, speaker: Speaker, volume: int):
         """Ramps volume to target volume for the passed Sonos speaker
 

--- a/frontend/src/pages/Overview/styles.module.css
+++ b/frontend/src/pages/Overview/styles.module.css
@@ -1,0 +1,3 @@
+.BalanceRoom {
+  margin-top: 16px;
+}


### PR DESCRIPTION
This interpolates the volume at the current position, sets the new volumes for all speakers, and displays their volume levels in the web interface.
For the balancing, the speaker volumes before balancing gets started are used as a reference. It is currently not possible for the user to change the volume after balancing has started, but I think we should search for a solution for this as it would lead to a better user experience.

Additionally, I've implemented a check that does not allow configuration changes while the balancing is active since this could lead to strange behaviors or even errors.

Theoretically, everything should also already work for multiple rooms.