### PR TITLE
User configurable calibration sound volume

### DIFF
--- a/backend/src/api/controllers/room_calibration.py
+++ b/backend/src/api/controllers/room_calibration.py
@@ -62,6 +62,8 @@ class RoomCalibrationController(AsyncNamespace):
                 ack.add_error('The room is already calibrating currently')
             elif start and start_volume is None:
                 ack.add_error('Calibration start volume is required')
+            elif start:
+                validate.integer(start_volume, label='Calibration Start Volume')
 
         if finish is not None:
             validate.boolean(finish, label='Finish')

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -25,6 +25,7 @@ class Room:
         self.name: str = name
         self.nodes: List[models.node.Node] = nodes or []
         self.calibrating: bool = False
+        self.calibration_volume: int = 30
         self.calibration_points: List[RoomCalibrationPoint] = []
         self.calibration_points_current_point: List[RoomCalibrationPoint] = []
         self.calibration_current_speaker_index = 0

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -161,6 +161,7 @@ type RoomCalibrationRequest = {
     id: number;
   };
   start?: boolean;
+  startVolume?: number;
   finish?: boolean;
   repeatPoint?: boolean;
   confirmPoint?: boolean;

--- a/frontend/src/components/Calibration/index.tsx
+++ b/frontend/src/components/Calibration/index.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
-import { Button, Alert, Space, Row, Col, Steps, Divider, Progress } from 'antd';
+import { Button, Alert, Space, Row, Col, Steps, Divider, Progress, Slider } from 'antd';
 import {
   RadarChartOutlined,
   CheckOutlined,
@@ -34,6 +34,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
   const { speakers } = useSpeakers();
 
   const [calibrationStarting, setCalibrationStarting] = useState(false);
+  const [calibrationVolume, setCalibrationVolume] = useState(0);
   const [calibrationFinishing, setCalibrationFinishing] = useState(false);
   const [calibrationNextPointing, setCalibrationNextPointing] = useState(false);
   const [calibrationConfirmingPoint, setCalibrationConfirmingPoint] = useState(false);
@@ -48,7 +49,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
       setCalibrationStep(0);
     }
   }, [setCalibrationStep, roomCalibration]);
-  
+
   useEffect(() => {
     if (!roomCalibration?.calibrating) return;
     prepareCalibration();
@@ -56,7 +57,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
 
   const onStartCalibration = async () => {
     setCalibrationStarting(true);
-    const ack = await startCalibration();
+    const ack = await startCalibration(calibrationVolume);
 
     if (!ack.successful) {
       setCalibrationStarting(false);
@@ -102,10 +103,15 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
       {audioMeterErrors.map((error, index) => (
         <Alert key={`ame${index}`} message={error} type="error" showIcon />
       ))}
-      {!roomCalibration?.calibrating ?
-        <Button type="primary" loading={calibrationStarting} icon={<RadarChartOutlined />} onClick={onStartCalibration}>
-          {roomCalibration?.previousPoints && roomCalibration.previousPoints.length > 0 ? 'Restart calibration' : 'Start calibration'}
-        </Button> :
+      {!roomCalibration?.calibrating ? <Space direction="vertical" className={styles.space}>
+          <Row gutter={10} align="middle">
+            <Col>Calibration Volume</Col>
+            <Col flex="auto"><Slider defaultValue={30} onChange={setCalibrationVolume} /></Col>
+          </Row>
+          <Button type="primary" loading={calibrationStarting} icon={<RadarChartOutlined />} onClick={onStartCalibration}>
+            {roomCalibration?.previousPoints && roomCalibration.previousPoints.length > 0 ? 'Restart calibration' : 'Start calibration'}
+          </Button>
+        </Space> :
         <>
           <Space direction="vertical" className={styles.space}>
             <Space>
@@ -120,7 +126,7 @@ const Calibration: FunctionComponent<CalibrationProps> = ({
                 <Steps progressDot direction="vertical" size="small" current={calibrationStep}>
                   <Steps.Step title="Position yourself" description={<>
                     <span>When you're at the desired location press</span>
-                    <br/>
+                    <br />
                     <Button type="default" disabled={calibrationStep !== 0} loading={calibrationNextPointing} onClick={onNextPoint}>Next Position</Button>
                   </>} />
                   {roomSpeakers.map((speaker, index) => <Steps.Step key={speaker.id} title={`Measuring ${speaker.name}`} description={<>

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -9,6 +9,7 @@ export type RoomCalibrationRequest = {
     id: number;
   };
   start?: boolean;
+  startVolume?: number;
   finish?: boolean;
   repeatPoint?: boolean;
   confirmPoint?: boolean;

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -99,12 +99,13 @@ export const useRoomCalibration = (roomId: number, calibrationMapCanvasRef: RefO
     prepareAudioMeter();
   }, []);
 
-  const startCalibration = useCallback((): Promise<Acknowledgment> => {
+  const startCalibration = useCallback((startVolume: number): Promise<Acknowledgment> => {
     const calibrationSocket = getSocket(socketRoomName);
     return new Promise(resolve => {    
       calibrationSocket.emit('update', {
         room: {id: roomId},
         start: true,
+        startVolume,
       }, (ack: Acknowledgment) => {
         if (!ack.successful && ack.errors !== undefined) {
           const ackErrors = ack.errors;


### PR DESCRIPTION
This fixes #55, by adding a slider above the `Start calibration` button, allowing the user to adjust the default calibration value. This is then used by the backend to play the calibration white noise.