### PR TITLE
Use larger subscription duration

### DIFF
--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -4,6 +4,7 @@ from models.speaker import Speaker
 import soco
 from soco import events_asyncio
 from soco.snapshot import Snapshot
+from soco.events_asyncio import Subscription
 from .adapter import SonosAdapter
 
 
@@ -107,9 +108,8 @@ class SonosSocoAdapter(SonosAdapter):
         :rtype: (soco.events_asyncio.Subscription, str)
         """
         coordinator = self.get_coordinator_instance(speaker)
-        subscription = await coordinator.renderingControl.subscribe(requested_timeout=300,
-                                                                    auto_renew=True)
-        subscription.callback = event_handler
+        subscription = Subscription(coordinator.renderingControl, event_handler)
+        await subscription.subscribe(requested_timeout=60*60*24, auto_renew=True)
 
         return (subscription, coordinator.ip_address)
 
@@ -170,7 +170,8 @@ class SonosSocoAdapter(SonosAdapter):
         for speaker in speakers:
             soco_instance = soco.SoCo(speaker.ip_address)
             if not any(x.uid == speaker.speaker_id for x in biggest_group.members):
-                print('[SoCo Adapter] Adding {} to the group of {}'.format(speaker.ip_address, biggest_group.coordinator.ip_address))
+                print('[SoCo Adapter] Adding {} to the group of {}'.format(
+                    speaker.ip_address, biggest_group.coordinator.ip_address))
                 if soco_instance.group is not None:
                     soco_instance.previous_group_coordinator = soco_instance.group.coordinator
                 soco_instance.join(biggest_group.coordinator)
@@ -184,7 +185,8 @@ class SonosSocoAdapter(SonosAdapter):
         for speaker in speakers:
             soco_instance = soco.SoCo(speaker.ip_address)
             if hasattr(soco_instance, 'previous_group_coordinator'):
-                print('[SoCo Adapter] Adding {} to the group of {}'.format(speaker.ip_address, soco_instance.previous_group_coordinator.ip_address))
+                print('[SoCo Adapter] Adding {} to the group of {}'.format(
+                    speaker.ip_address, soco_instance.previous_group_coordinator.ip_address))
                 if soco_instance.previous_group_coordinator != soco_instance:
                     soco_instance.join(soco_instance.previous_group_coordinator)
                 else:


### PR DESCRIPTION
I tried to manually renew the subscription and also a few other things and dove into the source code of SoCo. There is definitely a bug within the new async events module of SoCo as just the single call to `await subscription.renew()` throws the error that the coroutine was not awaited. Since there is clearly an await, it is thrown within SoCo. I think probably in the `_wrap` method of the async module.

So, until this gets fixed, I changed the subscription duration to one day, assuming that real-stereo will not run for a whole day without being unplugged/restarted. We can lower it again once fixed in SoCo, but I think there shouldn't be any issues with it.

(There are also a few formating changes my editor did when saving the file. I don't know why yours didn't as we should have the same dev container 😅 )