### PR TITLE
Force room re-calibration on node/speaker change

### DIFF
--- a/backend/src/api/controllers/nodes.py
+++ b/backend/src/api/controllers/nodes.py
@@ -102,8 +102,15 @@ class NodesController(AsyncNamespace):
             if node.room is None or node.room.room_id != room.room_id:
                 if node.room is not None:
                     node.room.nodes.remove(node)
+
+                    # force re-calibration of the old room
+                    node.room.force_recalibration()
+
                 node.room = room
                 node.room.nodes.append(node)
+
+                # force re-calibration of the new room
+                node.room.force_recalibration()
 
             # store the update and send the new state to all clients
             await self.config.node_repository.call_listeners()
@@ -128,6 +135,7 @@ class NodesController(AsyncNamespace):
 
         if ack.successful and node.room is not None:
             node.room.nodes.remove(node)
+            node.room.force_recalibration()
             node.room = None
 
             # store the update and send the new state to all clients

--- a/backend/src/models/room.py
+++ b/backend/src/models/room.py
@@ -37,6 +37,10 @@ class Room:
         self.user_volume: float = 0.0
         self.volume_interpolation = VolumeInterpolation(self)
 
+    def force_recalibration(self) -> None:
+        """Forces a re-calibration of the room."""
+        self.calibration_points = []
+
     @staticmethod
     def from_json(data: dict):
         """Reads data from a JSON object and returns a new room instance.

--- a/frontend/src/pages/Overview/index.tsx
+++ b/frontend/src/pages/Overview/index.tsx
@@ -34,7 +34,7 @@ const OverviewPage: FunctionComponent<{}> = () => {
   return (
     <>
       {saveErrors?.map((error, index) => (
-        <Alert key={index} message={error} type="error" showIcon />
+        <Alert key={index} message={error} type="error" showIcon className={styles.Error} />
       ))}
       {settings ? <Row>
         <Col flex="auto">Enable balancing</Col>

--- a/frontend/src/pages/Overview/styles.module.css
+++ b/frontend/src/pages/Overview/styles.module.css
@@ -1,3 +1,7 @@
+.Error {
+  margin-bottom: 16px;
+}
+
 .BalanceRoom {
   margin-top: 16px;
 }


### PR DESCRIPTION
To ensure that users won't have strange balancing, a re-calibration is forced when a node/speaker is assigned to a new/other room. Therefore, it is no longer possible to start balancing without or with an old room calibration.

Resolves #62 