### PR TITLE
Lower session renewal interval again

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -296,7 +296,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "soco"
-version = "0.22.1"
+version = "0.22.2"
 description = "SoCo (Sonos Controller) is a simple library to control Sonos speakers."
 category = "main"
 optional = false
@@ -638,8 +638,8 @@ six = [
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 soco = [
-    {file = "soco-0.22.1-py2.py3-none-any.whl", hash = "sha256:fe145f2d39a5f194e0887dd9c9fa81b1e3a7613f776d6ba1ec2eeb9becd6350d"},
-    {file = "soco-0.22.1.tar.gz", hash = "sha256:72939ff58ab28286174b69fb7aa3696bf8cf9fd55ff785698386e4109e097148"},
+    {file = "soco-0.22.2-py2.py3-none-any.whl", hash = "sha256:98efa10752f0be4b33534420dbc570dc4cb4dafca05fe329a9cf754b76444366"},
+    {file = "soco-0.22.2.tar.gz", hash = "sha256:fb6c93816f16340a57db26c9edfb654e078c113520ee4b5dbc01fc14672e16fa"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -109,7 +109,7 @@ class SonosSocoAdapter(SonosAdapter):
         """
         coordinator = self.get_coordinator_instance(speaker)
         subscription = Subscription(coordinator.renderingControl, event_handler)
-        await subscription.subscribe(requested_timeout=60*60*24, auto_renew=True)
+        await subscription.subscribe(requested_timeout=300, auto_renew=True)
 
         return (subscription, coordinator.ip_address)
 


### PR DESCRIPTION
As the session renewal bug got fixed, we can lower the interval again.
I think a larger one would also work, but since the PI can be plugged from the power at any time and we restart it even more often during development, a shorter interval prevents the Sonos speakers from having to call a list of unavailable event listeners.