### PR TITLE
Initial setup using a Ad Hoc Network

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 		"python.linting.pylintPath": "${workspaceFolder}/backend/.venv/bin/pylint",
 		"python.linting.pylintArgs": [
 			"--extension-pkg-whitelist=cv2",
+			"--extension-pkg-allow-list=netifaces",
 			"--load-plugins=pylint_protobuf"
 		],
 		"editor.formatOnSave": true,

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -194,6 +194,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "netifaces"
+version = "0.10.9"
+description = "Portable network interface information."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "protobuf"
 version = "3.15.8"
 description = "Protocol Buffers"
@@ -379,7 +387,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c4311f06895e6836e4c36f3032b0a8803dd7b00c9625fb340c88221f83c4c263"
+content-hash = "e5a9f20c054902aedc8efa64ac0f84b571d3e85909a79a558fac001ff77c37bb"
 
 [metadata.files]
 aiohttp = [
@@ -586,6 +594,30 @@ multidict = [
     {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
     {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
     {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
+]
+netifaces = [
+    {file = "netifaces-0.10.9-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:b2ff3a0a4f991d2da5376efd3365064a43909877e9fabfa801df970771161d29"},
+    {file = "netifaces-0.10.9-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:0c4304c6d5b33fbd9b20fdc369f3a2fef1a8bbacfb6fd05b9708db01333e9e7b"},
+    {file = "netifaces-0.10.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:7a25a8e28281504f0e23e181d7a9ed699c72f061ca6bdfcd96c423c2a89e75fc"},
+    {file = "netifaces-0.10.9-cp27-cp27m-win32.whl", hash = "sha256:6d84e50ec28e5d766c9911dce945412dc5b1ce760757c224c71e1a9759fa80c2"},
+    {file = "netifaces-0.10.9-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f911b7f0083d445c8d24cfa5b42ad4996e33250400492080f5018a28c026db2b"},
+    {file = "netifaces-0.10.9-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4921ed406386246b84465950d15a4f63480c1458b0979c272364054b29d73084"},
+    {file = "netifaces-0.10.9-cp33-cp33m-manylinux1_i686.whl", hash = "sha256:5b3167f923f67924b356c1338eb9ba275b2ba8d64c7c2c47cf5b5db49d574994"},
+    {file = "netifaces-0.10.9-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:db881478f1170c6dd524175ba1c83b99d3a6f992a35eca756de0ddc4690a1940"},
+    {file = "netifaces-0.10.9-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:f0427755c68571df37dc58835e53a4307884a48dec76f3c01e33eb0d4a3a81d7"},
+    {file = "netifaces-0.10.9-cp34-cp34m-win32.whl", hash = "sha256:7cc6fd1eca65be588f001005446a47981cbe0b2909f5be8feafef3bf351a4e24"},
+    {file = "netifaces-0.10.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:b47e8f9ff6846756be3dc3fb242ca8e86752cd35a08e06d54ffc2e2a2aca70ea"},
+    {file = "netifaces-0.10.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f8885cc48c8c7ad51f36c175e462840f163cb4687eeb6c6d7dfaf7197308e36b"},
+    {file = "netifaces-0.10.9-cp35-cp35m-win32.whl", hash = "sha256:755050799b5d5aedb1396046f270abfc4befca9ccba3074f3dbbb3cb34f13aae"},
+    {file = "netifaces-0.10.9-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:ad10acab2ef691eb29a1cc52c3be5ad1423700e993cc035066049fa72999d0dc"},
+    {file = "netifaces-0.10.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:563a1a366ee0fb3d96caab79b7ac7abd2c0a0577b157cc5a40301373a0501f89"},
+    {file = "netifaces-0.10.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:30ed89ab8aff715caf9a9d827aa69cd02ad9f6b1896fd3fb4beb998466ed9a3c"},
+    {file = "netifaces-0.10.9-cp36-cp36m-win32.whl", hash = "sha256:75d3a4ec5035db7478520ac547f7c176e9fd438269e795819b67223c486e5cbe"},
+    {file = "netifaces-0.10.9-cp36-cp36m-win_amd64.whl", hash = "sha256:078986caf4d6a602a4257d3686afe4544ea74362b8928e9f4389b5cd262bc215"},
+    {file = "netifaces-0.10.9-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:3095218b66d359092b82f07c5422293c2f6559cf8d36b96b379cc4cdc26eeffa"},
+    {file = "netifaces-0.10.9-cp37-cp37m-win32.whl", hash = "sha256:da298241d87bcf468aa0f0705ba14572ad296f24c4fda5055d6988701d6fd8e1"},
+    {file = "netifaces-0.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:86b8a140e891bb23c8b9cb1804f1475eb13eea3dbbebef01fcbbf10fbafbee42"},
+    {file = "netifaces-0.10.9.tar.gz", hash = "sha256:2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3"},
 ]
 protobuf = [
     {file = "protobuf-3.15.8-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fad4f971ec38d8df7f4b632c819bf9bbf4f57cfd7312cf526c69ce17ef32436a"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ soco = "^0.22.1"
 asyncio-dgram = "^1.2.0"
 imutils = "^0.5.4"
 cryptography = "^3.4.7"
+netifaces = "^0.10.9"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -26,7 +26,7 @@ async def main():
         cluster_slave = ClusterSlave(config, tracking)
         balancing = BalancingManager(config)
         cluster_master = ClusterMaster(config, cluster_slave, balancing)
-        api = ApiManager(config, tracking, cluster_master, balancing)
+        api = ApiManager(config, tracking, cluster_master, balancing, networking)
 
         await asyncio.gather(
             cluster_master.start(),

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -40,7 +40,7 @@ async def main():
         )
     else:
         cluster_slave = ClusterSlave(config, tracking)
-        api = ApiManager(config, tracking)
+        api = ApiManager(config, tracking, networking_manager=networking)
 
         await asyncio.gather(
             cluster_slave.start(),

--- a/backend/src/__main__.py
+++ b/backend/src/__main__.py
@@ -10,6 +10,7 @@ from config import Config, NodeType
 from balancing.manager import BalancingManager
 from protocol.master import ClusterMaster
 from protocol.slave import ClusterSlave
+from networking.manager import NetworkingManager
 
 
 async def main():
@@ -19,6 +20,7 @@ async def main():
     print('Starting as ' + str(config.type))
 
     tracking = TrackingManager(config)
+    networking = NetworkingManager(config)
 
     if config.type == NodeType.MASTER or '--master' in argv:
         cluster_slave = ClusterSlave(config, tracking)
@@ -34,6 +36,7 @@ async def main():
             tracking.await_frames(),
             tracking.await_coordinates(),
             tracking.await_camera_calibration_responses(),
+            networking.initial_check(),
         )
     else:
         cluster_slave = ClusterSlave(config, tracking)
@@ -45,6 +48,7 @@ async def main():
             tracking.await_frames(),
             tracking.await_coordinates(),
             tracking.await_camera_calibration_responses(),
+            networking.initial_check(),
         )
 
 

--- a/backend/src/api/controllers/networks.py
+++ b/backend/src/api/controllers/networks.py
@@ -1,0 +1,50 @@
+"""Controller for the /networks namespace."""
+
+from socketio import AsyncNamespace
+from models.acknowledgment import Acknowledgment
+from api.validate import Validate
+from networking.wpa_supplicant import WpaSupplicant
+
+
+class NetworksController(AsyncNamespace):
+    """Controller for the /networks namespace."""
+
+    def __init__(self):
+        super().__init__(namespace='/networks')
+        self.wpa_supplicant = WpaSupplicant()
+
+    def validate(self, data: dict) -> Acknowledgment:
+        """Validates the input data.
+
+        :param dict data: Input data
+        :returns: Acknowledgment with the status and possible error messages.
+        :rtype: models.acknowledgment.Acknowledgment
+        """
+        ack = Acknowledgment()
+        validate = Validate(ack)
+        ssid = data.get('ssid')
+        psk = data.get('psk')
+
+        validate.string(ssid, label='SSID', min_value=1)
+
+        if psk is not None:
+            validate.string(psk, label='Password', min_value=8, max_value=63)
+
+        return ack
+
+    async def on_create(self, _: str, data: dict) -> None:
+        """Stores a new network.
+
+        :param str sid: Session id
+        :param dict data: Event data
+        """
+        # validate
+        ack = self.validate(data)
+
+        if ack.successful:
+            ssid = data.get('ssid')
+            psk = data.get('psk')
+
+            self.wpa_supplicant.store_network(ssid, psk)
+
+        return ack.to_json()

--- a/backend/src/api/controllers/settings.py
+++ b/backend/src/api/controllers/settings.py
@@ -58,7 +58,7 @@ class SettingsController(AsyncNamespace):
 
         if data.get('network') is not None:
             network_ack = self.networks_controller.validate(data.get('network'))
-            if not network_ack.successful():
+            if not network_ack.successful:
                 for error in network_ack.errors:
                     ack.add_error(error)
 

--- a/backend/src/api/controllers/settings.py
+++ b/backend/src/api/controllers/settings.py
@@ -25,6 +25,7 @@ class SettingsController(AsyncNamespace):
         return {
             'configured': self.config.type != NodeType.UNCONFIGURED,
             'balance': self.config.balance,
+            'network': self.config.network,
         }
 
     async def send_settings(self, sid: str = None) -> None:

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -76,7 +76,6 @@ class ApiManager:
             self.server.register_namespace(NodesController(config=self.config,
                                                            cluster_master=cluster_master))
             self.server.register_namespace(SpeakersController(config=self.config))
-            self.server.register_namespace(SettingsController(config=self.config))
             self.server.register_namespace(CameraCalibrationController(config=self.config,
                                                                        cluster_master=cluster_master))
             self.server.register_namespace(RoomCalibrationController(config=self.config,
@@ -84,8 +83,11 @@ class ApiManager:
                                                                          balancing_manager, 'sonos', None),
                                                                      tracking_manager=tracking_manager,
                                                                      cluster_master=cluster_master))
-            self.server.register_namespace(NetworksController(config=self.config,
-                                                              networking_manager=networking_manager))
+            networks_controller = NetworksController(config=self.config,
+                                                     networking_manager=networking_manager)
+            self.server.register_namespace(networks_controller)
+            self.server.register_namespace(SettingsController(config=self.config,
+                                                              networks_controller=networks_controller))
 
             balances_controller = BalancesController()
             if balancing_manager is not None:

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -11,6 +11,7 @@ from config import Config, NodeType
 from tracking.manager import TrackingManager
 from protocol.master import ClusterMaster
 from balancing.manager import BalancingManager
+from networking.manager import NetworkingManager
 from .controllers.rooms import RoomsController
 from .controllers.nodes import NodesController
 from .controllers.speakers import SpeakersController
@@ -37,7 +38,8 @@ class ApiManager:
 
     def __init__(self, config: Config, tracking_manager: TrackingManager,
                  cluster_master: ClusterMaster = None,
-                 balancing_manager: BalancingManager = None):
+                 balancing_manager: BalancingManager = None,
+                 networking_manager: NetworkingManager = None):
         self.config: Config = config
         self.tracking_manager: TrackingManager = tracking_manager
         self.stream_queues: List[asyncio.Queue] = []
@@ -82,7 +84,9 @@ class ApiManager:
                                                                          balancing_manager, 'sonos', None),
                                                                      tracking_manager=tracking_manager,
                                                                      cluster_master=cluster_master))
-            self.server.register_namespace(NetworksController())
+            self.server.register_namespace(NetworksController(config=self.config,
+                                                              networking_manager=networking_manager))
+
             balances_controller = BalancesController()
             if balancing_manager is not None:
                 balancing_manager.balances_api_controller = balances_controller

--- a/backend/src/api/manager.py
+++ b/backend/src/api/manager.py
@@ -18,6 +18,7 @@ from .controllers.settings import SettingsController
 from .controllers.camera_calibration import CameraCalibrationController
 from .controllers.room_calibration import RoomCalibrationController
 from .controllers.balances import BalancesController
+from .controllers.networks import NetworksController
 from .ssl_generator import SSLGenerator
 
 # define path of the static frontend files
@@ -81,6 +82,7 @@ class ApiManager:
                                                                          balancing_manager, 'sonos', None),
                                                                      tracking_manager=tracking_manager,
                                                                      cluster_master=cluster_master))
+            self.server.register_namespace(NetworksController())
             balances_controller = BalancesController()
             if balancing_manager is not None:
                 balancing_manager.balances_api_controller = balances_controller

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -41,6 +41,7 @@ class Config:
         self.room_repository.register_listener(self.update_volume_interpolation)
         self.node_repository.register_listener(self.store)
         self.speaker_repository.register_listener(self.store)
+        self.setting_repository.register_listener(self.store)
 
         # load file if it exists
         if path.exists():

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -26,6 +26,7 @@ class Config:
         self.path: Path = path
         self.type: NodeType = NodeType.UNCONFIGURED
         self.balance: bool = False
+        self.network = 'client'
         self.rooms: List[Room] = []
         self.nodes: List[Node] = []
         self.speakers: List[Speaker] = []

--- a/backend/src/networking/__init__.py
+++ b/backend/src/networking/__init__.py
@@ -1,0 +1,1 @@
+"""Ad hoc network managing"""

--- a/backend/src/networking/ad_hoc_network.py
+++ b/backend/src/networking/ad_hoc_network.py
@@ -1,0 +1,88 @@
+"""Handles the Ad Hoc Network used for initial setup and wifi configuration."""
+from os import system
+
+
+DHCP_CONFIG = '/etc/dhcpcd.conf'
+DISABLED_START_POINTER = '# --ad-hoc-start--\n'
+ENABLED_START_POINTER = '# --ad-hoc-start-enabled--\n'
+END_POINTER = '# --ad-hoc-end--\n'
+
+
+class AdHocNetwork:
+    """Handles the Ad Hoc Network used for initial setup and wifi configuration."""
+
+    def is_enabled(self) -> bool:
+        """Check if the ad hoc network is enabled.
+
+        :returns: True if the ad hoc network is enabled
+        :rtype: bool
+        """
+        with open(DHCP_CONFIG, 'r') as config_file:
+            config = config_file.readlines()
+            return ENABLED_START_POINTER in config
+
+    async def enable(self):
+        """Enables the ad hoc network"""
+        print('[AdHoc] Enabling the ad hoc network')
+
+        # enable the ad hoc network in the dhcp config
+        with open(DHCP_CONFIG, 'r') as config_file:
+            config = config_file.readlines()
+            if DISABLED_START_POINTER in config:
+                start = config.index(DISABLED_START_POINTER)
+                config[start] = ENABLED_START_POINTER
+                for i in range(start + 1, config.index(END_POINTER)):
+                    if config[i][0] == '#':
+                        config[i] = config[i][1:]
+
+                with open(DHCP_CONFIG, 'w') as write_handle:
+                    write_handle.writelines(config)
+
+                    # reload daemon config
+                    system('sudo systemctl daemon-reload')
+
+        if system('sudo service hostapd status > /dev/null') > 0:
+            # enable the hostapd service
+            system('sudo systemctl enable --now hostapd')
+
+            # restart the network
+            self.restart_network()
+
+            # restart the hostapd service to use the new dhcp config
+            system('sudo service hostapd restart')
+
+    def disable(self):
+        """Disable the ad hoc network"""
+        print('[AdHoc] Disabling the ad hoc network')
+
+        # disable the ad hoc network in the dhcp config
+        with open(DHCP_CONFIG, 'r') as config_file:
+            config = config_file.readlines()
+            if ENABLED_START_POINTER in config:
+                start = config.index(ENABLED_START_POINTER)
+                config[start] = DISABLED_START_POINTER
+                for i in range(start + 1, config.index(END_POINTER)):
+                    if config[i][0] != '#':
+                        config[i] = '#' + config[i]
+
+                with open(DHCP_CONFIG, 'w') as write_handle:
+                    write_handle.writelines(config)
+
+                    # reload daemon config
+                    system('sudo systemctl daemon-reload')
+
+        if system('sudo service hostapd status > /dev/null') < 1:
+            # disable the hostapd service
+            system('sudo systemctl disable --now hostapd')
+
+            # restart the network
+            self.restart_network()
+
+    def restart_network(self) -> None:
+        """Restarts the dhcp service and network interface."""
+        # restart the dhcp service
+        system('sudo service dhcpcd restart')
+
+        # restart the network interface
+        system('sudo ifconfig wlan0 down')
+        system('sudo ifconfig wlan0 up')

--- a/backend/src/networking/ad_hoc_network.py
+++ b/backend/src/networking/ad_hoc_network.py
@@ -55,6 +55,9 @@ class AdHocNetwork:
             # restart the hostapd service to use the new dhcp config
             system('sudo service hostapd restart')
 
+            # enable the dhcp server for the adhoc network
+            system('sudo service enable --now dnsmasq')
+
         self.config.network = 'adhoc'
 
     def disable(self):
@@ -80,6 +83,9 @@ class AdHocNetwork:
         if system('sudo service hostapd status > /dev/null') < 1:
             # disable the hostapd service
             system('sudo systemctl disable --now hostapd')
+
+            # disable the dhcp server for the adhoc network
+            system('sudo service disable --now dnsmasq')
 
             # restart the network
             self.restart_network()

--- a/backend/src/networking/ad_hoc_network.py
+++ b/backend/src/networking/ad_hoc_network.py
@@ -1,5 +1,6 @@
 """Handles the Ad Hoc Network used for initial setup and wifi configuration."""
 from os import system
+from config import Config
 
 
 DHCP_CONFIG = '/etc/dhcpcd.conf'
@@ -11,6 +12,9 @@ END_POINTER = '# --ad-hoc-end--\n'
 class AdHocNetwork:
     """Handles the Ad Hoc Network used for initial setup and wifi configuration."""
 
+    def __init__(self, config: Config):
+        self.config = config
+
     def is_enabled(self) -> bool:
         """Check if the ad hoc network is enabled.
 
@@ -21,7 +25,7 @@ class AdHocNetwork:
             config = config_file.readlines()
             return ENABLED_START_POINTER in config
 
-    async def enable(self):
+    def enable(self):
         """Enables the ad hoc network"""
         print('[AdHoc] Enabling the ad hoc network')
 
@@ -51,6 +55,8 @@ class AdHocNetwork:
             # restart the hostapd service to use the new dhcp config
             system('sudo service hostapd restart')
 
+        self.config.network = 'adhoc'
+
     def disable(self):
         """Disable the ad hoc network"""
         print('[AdHoc] Disabling the ad hoc network')
@@ -77,6 +83,8 @@ class AdHocNetwork:
 
             # restart the network
             self.restart_network()
+
+        self.config.network = 'client'
 
     def restart_network(self) -> None:
         """Restarts the dhcp service and network interface."""

--- a/backend/src/networking/ad_hoc_network.py
+++ b/backend/src/networking/ad_hoc_network.py
@@ -56,7 +56,7 @@ class AdHocNetwork:
             system('sudo service hostapd restart')
 
             # enable the dhcp server for the adhoc network
-            system('sudo service enable --now dnsmasq')
+            system('sudo systemctl enable --now dnsmasq')
 
         self.config.network = 'adhoc'
 
@@ -85,7 +85,7 @@ class AdHocNetwork:
             system('sudo systemctl disable --now hostapd')
 
             # disable the dhcp server for the adhoc network
-            system('sudo service disable --now dnsmasq')
+            system('sudo systemctl disable --now dnsmasq')
 
             # restart the network
             self.restart_network()

--- a/backend/src/networking/manager.py
+++ b/backend/src/networking/manager.py
@@ -3,6 +3,7 @@ from asyncio import sleep
 import netifaces
 from config import Config, NodeType
 from .ad_hoc_network import AdHocNetwork
+from .wpa_supplicant import WpaSupplicant
 
 
 class NetworkingManager:
@@ -11,6 +12,7 @@ class NetworkingManager:
     def __init__(self, config: Config):
         self.config = config
         self.ad_hoc = AdHocNetwork(config)
+        self.wpa_supplicant = WpaSupplicant()
 
         if self.config.type == NodeType.UNCONFIGURED and not self.ad_hoc.is_enabled():
             self.ad_hoc.enable()
@@ -24,7 +26,7 @@ class NetworkingManager:
         """Initially checks if a network connection could be established.
         If not, it starts the adhoc network to allow the user to configure a new network.
         """
-        if self.config.type == NodeType.UNCONFIGURED:
+        if self.config.type == NodeType.UNCONFIGURED or self.config.network == 'adhoc':
             return
 
         await sleep(30)

--- a/backend/src/networking/manager.py
+++ b/backend/src/networking/manager.py
@@ -1,0 +1,45 @@
+"""Controls the networking functionality."""
+from asyncio import sleep
+import netifaces
+from config import Config, NodeType
+from .ad_hoc_network import AdHocNetwork
+
+
+class NetworkingManager:
+    """Controls the networking functionality."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.ad_hoc = AdHocNetwork(config)
+
+        if self.config.type == NodeType.UNCONFIGURED and not self.ad_hoc.is_enabled():
+            self.ad_hoc.enable()
+
+        if self.ad_hoc.is_enabled():
+            self.config.network = 'adhoc'
+        else:
+            self.config.network = 'client'
+
+    async def initial_check(self) -> None:
+        """Initially checks if a network connection could be established.
+        If not, it starts the adhoc network to allow the user to configure a new network.
+        """
+        if self.config.type == NodeType.UNCONFIGURED:
+            return
+
+        await sleep(30)
+
+        if not self.has_assigned_ip():
+            self.ad_hoc.enable()
+
+    def has_assigned_ip(self) -> bool:
+        """Checks whether an ip address is assigned to the network interface.
+
+        :returns: True if the network interface has an ip address assigned
+        :rtype: bool
+        """
+        if 'wlan0' not in netifaces.interfaces():
+            return False
+
+        addresses = netifaces.ifaddresses('wlan0')
+        return netifaces.AF_INET in addresses

--- a/backend/src/networking/wpa_supplicant.py
+++ b/backend/src/networking/wpa_supplicant.py
@@ -1,0 +1,58 @@
+"""Stores network configurations in the wpa_supplicant.conf file"""
+from os import system
+from shlex import quote
+
+
+WPA_SUPPLICANT_CONF = '/etc/wpa_supplicant/wpa_supplicant.conf'
+
+
+class WpaSupplicant:
+    """Stores network configurations in the wpa_supplicant.conf file"""
+
+    def store_network(self, ssid: str, psk: str = None) -> None:
+        """Stores a new network.
+
+        :param str ssid: Network SSID
+        :param str psk: Network password if it has one
+        """
+        self.remove_network(ssid)
+
+        if psk is not None and len(psk) > 0:
+            # encrypt the password and store it to the file
+            system('wpa_passphrase {} {} >> {}'.format(
+                quote(ssid), quote(psk), WPA_SUPPLICANT_CONF))
+        else:
+            # add the network without a password to the file
+            with open(WPA_SUPPLICANT_CONF, 'a') as write_handle:
+                write_handle.writelines([
+                    'network={\n',
+                    '\tssid="{}"\n'.format(ssid),
+                    '\tkey_mgmt=NONE\n',
+                    '}\n',
+                ])
+
+    def remove_network(self, ssid: str) -> None:
+        """Removes a network.
+
+        :param str ssid: Network SSID
+        """
+        with open(WPA_SUPPLICANT_CONF, 'r') as read_handle:
+            lines = read_handle.readlines()
+            ssid_search = 'ssid="{}"'.format(ssid.lower())
+            network_definition_start = -1
+            network_definition_end = 0
+
+            for index, line in enumerate(lines):
+                if line.strip().lower() == ssid_search:
+                    # definition starts one line above
+                    network_definition_start = index - 1
+                elif line.strip() == '}' and network_definition_start > 0:
+                    network_definition_end = index
+                    break
+            else:
+                # network does not exist
+                return
+
+            with open(WPA_SUPPLICANT_CONF, 'w') as write_handle:
+                write_handle.writelines(lines[:network_definition_start] +
+                                        lines[network_definition_end + 1:])

--- a/documents/raspberry-pi-setup.md
+++ b/documents/raspberry-pi-setup.md
@@ -16,19 +16,13 @@ This document provides a guide to set up a Raspberry Pi with the Real Stereo App
 1. (optional) To change the keyboard layout, run `sudo raspi-config` -> `5 Localisation Options` -> `L3 Keyboard`
 1. Connect the Raspberry Pi to the internet with an ethernet cable
 1. Run the install script by executing: `curl -sSL https://raw.githubusercontent.com/ItsEcholot/real-stereo-extended/main/scripts/pi-install.sh | bash -`
-1. When the installation has finished, the Raspberry Pi will restart and is ready to use. The real stereo application will start automatically and listens on port `8080`.
+1. When the installation has finished, the Raspberry Pi will restart and is ready to use. The real stereo application will start automatically and is available at https://10.1.1.1:8080 within the ad hoc network.
 
 ### Optimizing OpenCV
 
 It is possible to build opencv optimized for a raspberry pi which results in up to 200% better performance.
 To do so, simply run `/home/pi/real-stereo-extended/scripts/pi-optimize-opencv.sh`.
 The whole process can take up to 2 hours.
-
-### Wifi setup
-
-Until the feature has been implement into real stereo that the web interface provides a way to connect to a wifi network, you have to do it manually.
-
-To do so, simply run `sudo raspi-config` -> `1 System Options` -> `S1 Wireless LAN`
 
 ### SSH
 

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -121,6 +121,7 @@ type Settings = {
 
 type UpdateSettings = {
   balance: boolean;
+  nodeType?: 'master' | 'tracking';
 }
 ```
 

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -116,10 +116,20 @@ type Balance = {
 type Settings = {
   configured: boolean;
   balance: boolean;
+  network: 'client' | 'adhoc';
 }
 
 type UpdateSettings = {
   balance: boolean;
+}
+```
+
+#### `Network`
+
+```typescript
+type CreateNetwork = {
+  ssid: string;
+  psk?: string;
 }
 ```
 
@@ -249,3 +259,10 @@ Updates the camera calibration process.
 Available events:
 - `get: () => CameraCalibrationResponse`
 - `update: (data: CameraCalibrationRequest) => Acknowledgment`
+
+#### `/networks`
+
+Stores WLAN network configuration.
+
+Available events:
+- `create: (data: CreateNetwork) => Acknowledgment`

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -122,6 +122,7 @@ type Settings = {
 type UpdateSettings = {
   balance: boolean;
   nodeType?: 'master' | 'tracking';
+  network?: CreateNetwork;
 }
 ```
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,38 +10,49 @@ import EditNodePage from './pages/EditNode';
 import './App.css';
 import TestModePage from './pages/TestMode';
 import CalibrateCameraPage from './pages/CalibrateCamera';
+import SetupPage from './pages/Setup';
+import RequireSetup from './components/RequireSetup';
+import SetupFinishedPage from './pages/SetupFinished';
 
 const App: FunctionComponent<{}> = () => {
   return (
     <SocketProvider>
       <Router>
         <Layout>
-          <Switch>
-            <Route exact path="/">
-              <OverviewPage />
-            </Route>
-            <Route exact path="/nodes/add">
-              <AddCameraNodesPages />
-            </Route>
-            <Route exact path="/nodes/:nodeId" render={props => (
-              <EditNodePage nodeId={parseInt(props.match.params.nodeId, 10)} />
-            )} />
-            <Route exact path="/nodes/:nodeId/calibrate-camera" render={props => (
-              <CalibrateCameraPage nodeId={parseInt(props.match.params.nodeId, 10)} />
-            )} />
-            <Route exact path="/rooms/edit">
-              <EditRoomsPage />
-            </Route>
-            <Route exact path="/rooms/new/edit" >
-              <EditRoomPage />
-            </Route>
-            <Route exact path="/rooms/:roomId/edit" render={props => (
-              <EditRoomPage roomId={parseInt(props.match.params.roomId, 10)} />
-            )} />
-            <Route exact path="/testmode">
-              <TestModePage />
-            </Route>
-          </Switch>
+          <RequireSetup>
+            <Switch>
+              <Route exact path="/">
+                <OverviewPage />
+              </Route>
+              <Route exact path="/setup">
+                <SetupPage />
+              </Route>
+              <Route exact path="/setup/finished/:nodeType" render={props => (
+                <SetupFinishedPage nodeType={props.match.params.nodeType as 'master' | 'tracking'} />
+              )} />
+              <Route exact path="/nodes/add">
+                <AddCameraNodesPages />
+              </Route>
+              <Route exact path="/nodes/:nodeId" render={props => (
+                <EditNodePage nodeId={parseInt(props.match.params.nodeId, 10)} />
+              )} />
+              <Route exact path="/nodes/:nodeId/calibrate-camera" render={props => (
+                <CalibrateCameraPage nodeId={parseInt(props.match.params.nodeId, 10)} />
+              )} />
+              <Route exact path="/rooms/edit">
+                <EditRoomsPage />
+              </Route>
+              <Route exact path="/rooms/new/edit" >
+                <EditRoomPage />
+              </Route>
+              <Route exact path="/rooms/:roomId/edit" render={props => (
+                <EditRoomPage roomId={parseInt(props.match.params.roomId, 10)} />
+              )} />
+              <Route exact path="/testmode">
+                <TestModePage />
+              </Route>
+            </Switch>
+          </RequireSetup>
         </Layout>
       </Router>
     </SocketProvider>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -8,21 +8,23 @@ import styles from './styles.module.css';
 
 type HeaderProps = {
   title: string;
+  hasSider: boolean;
   siderCollapsed: boolean;
   onSiderCollapse: (siderCollapsed: boolean) => void;
 }
 
 const Header: FunctionComponent<HeaderProps> = ({
   title,
+  hasSider,
   siderCollapsed,
   onSiderCollapse: onSiderCollapseSwitch
 }) => {
   return (
     <Layout.Header className={styles.header}>
       <Space size="middle">
-        {siderCollapsed ?
+        {hasSider && siderCollapsed ?
           <MenuUnfoldOutlined onClick={() => onSiderCollapseSwitch(false)} /> :
-          <MenuFoldOutlined onClick={() => onSiderCollapseSwitch(true)} />}
+          hasSider && <MenuFoldOutlined onClick={() => onSiderCollapseSwitch(true)} />}
 
         <span className={styles.title}>{title}</span>
       </Space>

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -3,16 +3,19 @@ import { Layout as AntdLayout, Row, Col } from 'antd';
 import Header from '../Header';
 import MainMenu from '../MainMenu';
 import styles from './styles.module.css';
+import { useLocation } from 'react-router';
 
 const { Sider, Content } = AntdLayout;
 
 const Layout: FunctionComponent<{}> = props => {
   const [siderCollapsed, setSiderCollapsed] = useState(false);
   const [siderBroken, setSiderBroken] = useState(false);
+  const location = useLocation();
+  const hasSider = !location.pathname.startsWith('/setup');
 
   return (
     <AntdLayout className={siderBroken ? (siderCollapsed ? styles.layoutSiderCollapsed : styles.layoutSiderExpanded) : ''}>
-      <Sider
+      {hasSider && <Sider
         breakpoint="lg"
         collapsedWidth="0"
         onBreakpoint={broken => {
@@ -23,9 +26,9 @@ const Layout: FunctionComponent<{}> = props => {
         trigger={null}
         className={styles.sider}>
         <MainMenu siderBroken={siderBroken} onSiderCollapse={setSiderCollapsed} />
-      </Sider>
-      <AntdLayout>
-        <Header title="Real Stereo" siderCollapsed={siderCollapsed} onSiderCollapse={setSiderCollapsed} />
+      </Sider>}
+      <AntdLayout className={styles.fullHeight}>
+        <Header title="Real Stereo" hasSider={hasSider} siderCollapsed={siderCollapsed} onSiderCollapse={setSiderCollapsed} />
         <Content className={styles.content}>
           <Row justify="center">
             <Col xl={8} lg={12} md={16} xs={24}>

--- a/frontend/src/components/Layout/styles.module.css
+++ b/frontend/src/components/Layout/styles.module.css
@@ -13,3 +13,7 @@
 .content {
   padding: 20px;
 }
+
+.fullHeight {
+  min-height: 100vh !important;
+}

--- a/frontend/src/components/NodeSetupType/index.tsx
+++ b/frontend/src/components/NodeSetupType/index.tsx
@@ -1,0 +1,26 @@
+import { Card, Col, Row, Typography } from 'antd';
+import { FunctionComponent, ReactNode } from 'react';
+import styles from './styles.module.css';
+
+type NodeSetupTypeProps = {
+  icon: ReactNode;
+  text: string;
+  onClick: () => void;
+}
+
+const NodeSetupType: FunctionComponent<NodeSetupTypeProps> = ({ icon, text, onClick }) => (
+  <Card hoverable className={styles.Card} onClick={onClick}>
+    <Row justify="center" className={styles.IconRow}>
+      <Col>
+        {icon}
+      </Col>
+    </Row>
+    <Row justify="center">
+      <Col>
+        <Typography.Text className={styles.Text}>{text}</Typography.Text>
+      </Col>
+    </Row>
+  </Card>
+);
+
+export default NodeSetupType;

--- a/frontend/src/components/NodeSetupType/styles.module.css
+++ b/frontend/src/components/NodeSetupType/styles.module.css
@@ -1,0 +1,20 @@
+.Card {
+  width: 100%;
+  margin-top: 16px;
+}
+
+.IconRow span {
+  margin: auto;
+}
+
+.IconRow span svg {
+  width: 64px;
+  height: 64px;
+}
+
+.Text {
+  display: inline-block;
+  margin-top: 16px;
+  text-align: center;
+  font-size: 16px;
+}

--- a/frontend/src/components/RequireSetup/index.tsx
+++ b/frontend/src/components/RequireSetup/index.tsx
@@ -7,7 +7,7 @@ const RequireSetup: FunctionComponent<{}> = ({ children }) => {
   const location = useLocation();
 
   // redirect to setup page if necessary
-  if (settings && settings.network === 'adhoc' && !location.pathname.startsWith('/setup')) {
+  if (settings && (settings.network === 'adhoc' || !settings.configured) && !location.pathname.startsWith('/setup')) {
     return <Redirect to="/setup" />
   }
 

--- a/frontend/src/components/RequireSetup/index.tsx
+++ b/frontend/src/components/RequireSetup/index.tsx
@@ -1,0 +1,21 @@
+import { FunctionComponent } from 'react';
+import { Redirect, useLocation } from 'react-router';
+import { useSettings } from '../../services/settings';
+
+const RequireSetup: FunctionComponent<{}> = ({ children }) => {
+  const { settings } = useSettings();
+  const location = useLocation();
+
+  // redirect to setup page if necessary
+  if (settings && settings.network === 'adhoc' && !location.pathname.startsWith('/setup')) {
+    return <Redirect to="/setup" />
+  }
+
+  return (
+    <>
+      {children}
+    </>
+  );
+}
+
+export default RequireSetup;

--- a/frontend/src/pages/Setup/index.tsx
+++ b/frontend/src/pages/Setup/index.tsx
@@ -20,12 +20,13 @@ const SetupPage: FunctionComponent<{}> = () => {
     setSaving(true);
 
     try {
-      await createNetwork(values);
-
-      if (!settings?.configured) {
+      if (settings && settings.configured) {
+        await createNetwork(values);
+      } else {
         await updateSettings({
           balance: false,
           nodeType,
+          network: values,
         });
       }
 

--- a/frontend/src/pages/Setup/index.tsx
+++ b/frontend/src/pages/Setup/index.tsx
@@ -1,0 +1,132 @@
+import { FunctionComponent, useState } from 'react';
+import { Alert, Button, Col, Form, Input, Row, Spin, Typography } from 'antd';
+import { VideoCameraTwoTone, ControlTwoTone, CheckOutlined } from '@ant-design/icons';
+import NodeSetupType from '../../components/NodeSetupType';
+import { useSettings } from '../../services/settings';
+import styles from './styles.module.css';
+import { useNetworks } from '../../services/networks';
+import { useHistory } from 'react-router';
+
+const SetupPage: FunctionComponent<{}> = () => {
+  const history = useHistory();
+  const { settings, updateSettings } = useSettings();
+  const { createNetwork } = useNetworks();
+  const [nodeType, setNodeType] = useState<'master' | 'tracking'>();
+  const [saving, setSaving] = useState<boolean>(false);
+  const [form] = Form.useForm();
+  const [errors, setErrors] = useState<string[]>();
+
+  const save = async (values: { ssid: string, psk: string }) => {
+    setSaving(true);
+
+    try {
+      await createNetwork(values);
+
+      if (!settings?.configured) {
+        await updateSettings({
+          balance: false,
+          nodeType,
+        });
+      }
+
+      history.push(`/setup/finished/${nodeType || 'tracking'}`);
+    } catch (ack) {
+      setSaving(false);
+      setErrors(ack.errors);
+    }
+  };
+
+  if (!settings) {
+    return (
+      <Row justify="center"><Spin /></Row>
+    );
+  }
+
+  // require the user to select a node type if it is currently unconfigured
+  if (!settings.configured && !nodeType) {
+    return (
+      <>
+        {errors?.map((error, index) => (
+          <Alert key={index} message={error} type="error" showIcon />
+        ))}
+        <Row>
+          <Col>
+            <Typography.Title level={3}>Welcome to Real Stereo!</Typography.Title>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <Typography.Text>Is this the first Real Stereo device you are setting up in this network?</Typography.Text>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <NodeSetupType
+              text="Yes, set it up as the coordinator node."
+              icon={<ControlTwoTone />}
+              onClick={() => setNodeType('master')}
+            />
+            <NodeSetupType
+              text="No, set it up as a camera node and join an existing network."
+              icon={<VideoCameraTwoTone />}
+              onClick={() => setNodeType('tracking')}
+            />
+          </Col>
+        </Row>
+      </>
+    );
+  }
+
+  // as the second setup, ask for a wireless network to join
+  return (
+    <>
+      {errors?.map((error, index) => (
+        <Alert key={index} message={error} type="error" showIcon />
+      ))}
+      <Row>
+        <Typography.Title level={3}>WLAN Configuration</Typography.Title>
+        <Typography.Text>
+          Each Real Stereo device needs to join the same wireless network in order to communicate with each other.
+          Please specify the credentials to join one.
+          If you already have other Real Stereo devices running, make sure to use the same network.
+        </Typography.Text>
+      </Row>
+      <Row className={styles.FormRow}>
+        <Col xs={24}>
+          <Form
+            form={form}
+            labelCol={{ span: 12 }}
+            wrapperCol={{ span: 12 }}
+            labelAlign="left"
+            onFinish={save}>
+            <Form.Item
+              label="SSID (Name)"
+              name="ssid"
+              required
+              requiredMark
+              rules={[{ required: true, message: 'Please specify a SSID' }]}>
+              <Input />
+            </Form.Item>
+            <Form.Item
+              label="Password"
+              name="psk"
+              rules={[{
+                min: 8,
+                message: 'Password must be between 8 and 63 characters',
+              }, {
+                max: 63,
+                message: 'Password must be between 8 and 63 characters',
+              }]}>
+              <Input type="password" />
+            </Form.Item>
+            <Form.Item>
+              <Button type="primary" icon={<CheckOutlined />} htmlType="submit" loading={saving}>Save</Button>
+            </Form.Item>
+          </Form>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default SetupPage;

--- a/frontend/src/pages/Setup/styles.module.css
+++ b/frontend/src/pages/Setup/styles.module.css
@@ -1,0 +1,3 @@
+.FormRow {
+  margin-top: 16px;
+}

--- a/frontend/src/pages/SetupFinished/index.tsx
+++ b/frontend/src/pages/SetupFinished/index.tsx
@@ -1,0 +1,37 @@
+import { FunctionComponent } from 'react';
+import { Col, Row, Typography } from 'antd';
+import { VideoCameraTwoTone, ControlTwoTone } from '@ant-design/icons';
+import styles from './styles.module.css';
+
+type SetupFinishedPageProps = {
+  nodeType: 'master' | 'tracking';
+}
+
+const SetupFinishedPage: FunctionComponent<SetupFinishedPageProps> = ({ nodeType }) => (
+  <>
+    <Row justify="center">
+      <Col>
+        {nodeType === 'master'
+          ? <ControlTwoTone className={styles.Icon} />
+          : <VideoCameraTwoTone className={styles.Icon} />}
+      </Col>
+    </Row>
+    <Row>
+      <Col>
+        <Typography.Title level={3}>Setup finished</Typography.Title>
+        <Typography.Text>Congratulations, you have just set up a Real Stereo device!</Typography.Text>
+        <br />
+        <Typography.Text>
+          The device will now join the wireless network you have specified.
+          If there should be any problem during this process, this configuration WLAN will be available again after one minute and you can modify the configuration.
+        </Typography.Text>
+        <br />
+        {nodeType === 'master'
+          ? <Typography.Text>When the device successfully joined the wireless network, the administrator interface is available at https://IP_OF_THE_DEVICE:8080</Typography.Text>
+          : <Typography.Text>When the device successfully joined the wireless network, it will automatically connect to the coordinator node and should appear in the administrator interface after about one minute.</Typography.Text>}
+      </Col>
+    </Row>
+  </>
+);
+
+export default SetupFinishedPage;

--- a/frontend/src/pages/SetupFinished/styles.module.css
+++ b/frontend/src/pages/SetupFinished/styles.module.css
@@ -1,0 +1,8 @@
+.Icon {
+  margin-bottom: 32px;
+}
+
+.Icon svg {
+  width: 64px;
+  height: 64px;
+}

--- a/frontend/src/services/networks.tsx
+++ b/frontend/src/services/networks.tsx
@@ -1,0 +1,25 @@
+import { useCallback, useContext } from 'react';
+import { Acknowledgment } from './acknowledgment';
+import { SocketContext } from './socketProvider';
+
+export type CreateNetwork = {
+  ssid: string;
+  psk?: string;
+};
+
+export const useNetworks = () => {
+  const { getSocket, returnSocket } = useContext(SocketContext);
+
+  const createNetwork = useCallback((network: CreateNetwork): Promise<Acknowledgment> => {
+    const networksSocket = getSocket('networks');
+    return new Promise((resolve, reject) => {
+      networksSocket.emit('create', network, (ack: Acknowledgment) => {
+        if (ack.successful) resolve(ack);
+        else reject(ack);
+        returnSocket('networks');
+      })
+    });
+  }, [getSocket, returnSocket]);
+
+  return { createNetwork };
+};

--- a/frontend/src/services/settings.tsx
+++ b/frontend/src/services/settings.tsx
@@ -5,10 +5,12 @@ import { SocketContext } from './socketProvider';
 export type Settings = {
   configured: boolean;
   balance: boolean;
+  network: 'client' | 'adhoc';
 }
 
 export type UpdateSettings = {
   balance: boolean;
+  nodeType?: 'master' | 'tracking';
 }
 
 export const useSettings = () => {

--- a/frontend/src/services/settings.tsx
+++ b/frontend/src/services/settings.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState, useEffect, useCallback } from 'react';
 import { Acknowledgment } from './acknowledgment';
+import { CreateNetwork } from './networks';
 import { SocketContext } from './socketProvider';
 
 export type Settings = {
@@ -11,6 +12,7 @@ export type Settings = {
 export type UpdateSettings = {
   balance: boolean;
   nodeType?: 'master' | 'tracking';
+  network?: CreateNetwork;
 }
 
 export const useSettings = () => {

--- a/scripts/config/hostapd.conf
+++ b/scripts/config/hostapd.conf
@@ -1,0 +1,8 @@
+country_code=CH
+interface=wlan0
+ssid=Real Stereo (--hostname--)
+hw_mode=g
+channel=7
+macaddr_acl=0
+auth_algs=1
+ignore_broadcast_ssid=0

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -94,6 +94,7 @@ fi
 # change the hostname
 if [[ $(hostname) == 'raspberrypi' ]]; then
   echo "rse-$(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/random)" | sudo dd of=/etc/hostname
+  echo -e "127.0.0.1\t$(cat /etc/hostname)" | sudo dd of=/etc/hosts oflag=append conv=notrunc
 fi
 
 # setup the ad hoc network
@@ -106,7 +107,7 @@ if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
 
   echo -e "interface wlan0\n    static ip_address=10.1.1.1/24\n    nohook wpa_supplicant" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
   sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf
-  sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-9)/g" /etc/hostapd/hostapd.conf
+  sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-8)/g" /etc/hostapd/hostapd.conf
 fi
 
 # reboot to apply all config changes

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -96,5 +96,15 @@ if [[ $(hostname) == 'raspberrypi' ]]; then
   echo "rse-$(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/random)" | sudo dd of=/etc/hostname
 fi
 
+# setup the ad hoc network
+if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
+  sudo apt-get install -y hostapd dnsmasq
+  sudo systemctl unmask hostapd
+
+  echo -e "interface wlan0\n    static ip_address=10.1.1.1/24\n    nohook wpa_supplicant" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
+  sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf
+  sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-9)/g" /etc/hostapd/hostapd.conf
+fi
+
 # reboot to apply all config changes
 sudo shutdown -r now

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -100,6 +100,9 @@ fi
 if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
   sudo apt-get install -y hostapd dnsmasq
   sudo systemctl unmask hostapd
+  sudo systemctl disable hostapd
+  sudo systemctl disable dhcpcd
+  sudo systemctl disable dnsmasq
 
   echo -e "interface wlan0\n    static ip_address=10.1.1.1/24\n    nohook wpa_supplicant" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
   sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -69,7 +69,8 @@ sudo systemctl start real-stereo
 
 # set up wifi
 if [[ ! $(sudo cat /etc/wpa_supplicant/wpa_supplicant.conf | grep 'country') ]]; then
-  sudo cp $PROJECT_DIR/scripts/config/wpa_supplicant.conf /boot/wpa_supplicant.conf
+  sudo cp $PROJECT_DIR/scripts/config/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
+  sudo chown pi:root /etc/wpa_supplicant/wpa_supplicant.conf
   sudo rfkill unblock wifi
   sudo ifconfig wlan0 up
 fi
@@ -101,7 +102,9 @@ fi
 if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
   sudo apt-get install -y hostapd dnsmasq
 
-  echo -e "# --ad-hoc-start--\n#interface wlan0\n#    static ip_address=10.1.1.1/24\n#    nohook wpa_supplicant\n# --ad-hoc-end--" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
+  sudo chown pi:root /etc/dhcpcd.conf
+
+  echo -e "# --ad-hoc-start--\n#interface wlan0\n#    static ip_address=10.1.1.1/24\n#    nohook wpa_supplicant\n# --ad-hoc-end--" >> /etc/dhcpcd.conf
   sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf
   sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-8)/g" /etc/hostapd/hostapd.conf
 

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -100,14 +100,16 @@ fi
 # setup the ad hoc network
 if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
   sudo apt-get install -y hostapd dnsmasq
-  sudo systemctl unmask hostapd
-  sudo systemctl disable hostapd
-  sudo systemctl disable dhcpcd
-  sudo systemctl disable dnsmasq
 
-  echo -e "interface wlan0\n    static ip_address=10.1.1.1/24\n    nohook wpa_supplicant" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
+  echo -e "# --ad-hoc-start--\n#interface wlan0\n#    static ip_address=10.1.1.1/24\n#    nohook wpa_supplicant\n# --ad-hoc-end--" | sudo dd of=/etc/dhcpcd.conf oflag=append conv=notrunc
   sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf
   sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-8)/g" /etc/hostapd/hostapd.conf
+
+  sudo systemctl daemon-reload
+  sudo systemctl unmask hostapd
+  sudo systemctl disable hostapd
+  sudo systemctl disable dnsmasq
+  sudo systemctl enable dhcpcd
 fi
 
 # reboot to apply all config changes

--- a/scripts/pi-install.sh
+++ b/scripts/pi-install.sh
@@ -107,6 +107,7 @@ if [[ ! -f /etc/dhcp/dhcpd.conf ]]; then
   echo -e "# --ad-hoc-start--\n#interface wlan0\n#    static ip_address=10.1.1.1/24\n#    nohook wpa_supplicant\n# --ad-hoc-end--" >> /etc/dhcpcd.conf
   sudo cp "$PROJECT_DIR/scripts/config/hostapd.conf" /etc/hostapd/hostapd.conf
   sudo sed -i "s/--hostname--/$(cat /etc/hostname | head -n 1 | cut -c5-8)/g" /etc/hostapd/hostapd.conf
+  echo -e "interface=wlan0\ndhcp-range=10.1.1.10,10.1.1.250,255.255.255.0,24h\ndomain=local\naddress=/setup.rse/10.1.1.1" | sudo dd of=/etc/dnsmasq.conf oflag=append conv=notrunc
 
   sudo systemctl daemon-reload
   sudo systemctl unmask hostapd


### PR DESCRIPTION
It took quite some time to find a working and reliable solution and to find out which services need to be restarted in which order so no reboot of the PI is required when enabling/disabling the ad hoc network. But it is working reliably now.

### Initial setup
If started for the first time (`"type":"unconfigured"`), the PI enables the ad hoc network and shows the configuration page. The PI is available at `https://10.1.1.1:8080` within the ad hoc network, which name is `Real Stereo (xxxx)` (xxxx = first 4 chars of the hostname).
Once the configuration is done, the real-stereo process exits to allow the correct services to be started in the `__main__` after the type has been set to master or tracking. So, if you are running the process manually during development, you have to start it again. In the normal setup, when the process is running through systemd, it gets restarted automatically.

### Network unavailable
If the PI did not join a network after 30s of starting it, the ad hoc network will get enabled again so the user can configure a new wireless network. This allows it to be setup in another environment (e.g. at ZHAW) or when the SSID or password of the network has changed.

### Testing this PR
You can manually execute the commands in the `pi-install.sh` script (make sure to synchronize the scripts & configs before).
But the more reliable way is to set it up from scratch again. In this case, run the following command instead of the one mentioned in the setup document:
```bash
# see the feature/initial-setup instead of main within the curl command & the export
export PROJECT_BRANCH="feature/initial-setup" && curl -sSL https://raw.githubusercontent.com/ItsEcholot/real-stereo-extended/feature/initial-setup/scripts/pi-install.sh | bash -
```