### PR TITLE
Fix opencv optimization

### DIFF
--- a/scripts/pi-optimize-opencv.sh
+++ b/scripts/pi-optimize-opencv.sh
@@ -22,8 +22,9 @@ if [[ $(pip3 list | grep opencv) ]]; then
 fi
 
 # clone TBB
-git clone --depth 1 https://github.com/oneapi-src/oneTBB.git /home/pi/tbb
+git clone https://github.com/oneapi-src/oneTBB.git /home/pi/tbb
 cd /home/pi/tbb
+git checkout 9e15720bc7744f85dff611d34d65e9099e077da4
 CXXFLAGS="-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0" cmake -DTBB_TEST:BOOL=OFF --configure .
 CXXFLAGS="-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0" cmake --build .
 sudo cmake -DCOMPONENT=runtime -P cmake_install.cmake


### PR DESCRIPTION
I experienced some errors during the opencv optimization on the freshly installed PI. It turns out that some upstream change of TBB caused this (since we just use the newest git commit to build the source).
This PR pins the TBB version to one that does not contain the errors.