### PR TITLE
Retrieve hostname and ip more reliably

### DIFF
--- a/backend/src/api/controllers/room_calibration.py
+++ b/backend/src/api/controllers/room_calibration.py
@@ -164,7 +164,8 @@ class RoomCalibrationController(AsyncNamespace):
 
                 # send service update to all nodes of this room
                 for node in room.nodes:
-                    self.cluster_master.send_service_update(node.ip_address, True)
+                    if node.acquired:
+                        self.cluster_master.send_service_update(node.ip_address, True)
 
                 print('[Room Calibration] Starting for room {}'.format(room.name))
             elif data.get('finish'):

--- a/backend/src/networking/helpers.py
+++ b/backend/src/networking/helpers.py
@@ -1,0 +1,28 @@
+"""Some networking helper functions."""
+import netifaces
+
+
+def get_hostname() -> str:
+    """Returns the hostname of the machine.
+
+    :returns: Hostname
+    :rtype: str
+    """
+    with open('/etc/hostname', 'r') as file:
+        return file.readline().strip()
+
+
+def get_ip_address() -> str:
+    """Returns the ip address of the machine.
+
+    :returns: Ip address
+    :rtype: str
+    """
+    if 'wlan0' not in netifaces.interfaces():
+        return None
+
+    addresses = netifaces.ifaddresses('wlan0')
+    if netifaces.AF_INET not in addresses or len(addresses[netifaces.AF_INET]) < 1:
+        return None
+
+    return addresses[netifaces.AF_INET][0]['addr']

--- a/backend/src/protocol/master/master.py
+++ b/backend/src/protocol/master/master.py
@@ -1,10 +1,11 @@
 """Master for the cluster protocol."""
 
-from socket import socket, gethostname, AF_INET, SOCK_STREAM, MSG_DONTWAIT, MSG_PEEK
+from socket import socket, AF_INET, SOCK_STREAM, MSG_DONTWAIT, MSG_PEEK
 import asyncio
 import asyncio_dgram
 from config import Config
 from balancing.manager import BalancingManager
+from networking.helpers import get_hostname
 from ..socket import ClusterSocket
 from ..constants import PORT
 from ..cluster_pb2 import Wrapper
@@ -21,7 +22,7 @@ class ClusterMaster(ClusterSocket):
         self.direct_slave = direct_slave
         self.balancing_manager = balancing_manager
         self.node_registry = NodeRegistry(config, self)
-        self.hostname = gethostname()
+        self.hostname = get_hostname()
         self.slave_sockets = {}
         self.camera_calibration_response_listener = None
 

--- a/backend/src/protocol/master/node_registry.py
+++ b/backend/src/protocol/master/node_registry.py
@@ -1,9 +1,9 @@
 """Holds information about all available nodes and their state."""
 from time import time
-from socket import gethostname, gethostbyname
 import asyncio
 from config import Config
 from models.node import Node
+from networking.helpers import get_hostname, get_ip_address
 from ..constants import MASTER_PING_INTERVAL, NODE_AVAILABILITY_CHECK_INTERVAL
 from ..cluster_pb2 import Wrapper
 
@@ -106,11 +106,10 @@ class NodeRegistry:
 
     async def add_self(self) -> None:
         """Adds the master as a node since it also runs a camera node instance."""
-        hostname = gethostname()
+        hostname = get_hostname()
 
-        try:
-            self.master_ip = gethostbyname(hostname)
-        except:  # pylint: disable=bare-except
+        self.master_ip = get_ip_address()
+        if self.master_ip is None:
             self.master_ip = '127.0.0.1'
 
         if self.master.direct_slave is not None:

--- a/backend/src/protocol/slave/slave.py
+++ b/backend/src/protocol/slave/slave.py
@@ -2,8 +2,9 @@
 
 import asyncio
 from time import time
-from socket import socket, gethostname, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST
+from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST
 from config import NodeType
+from networking.helpers import get_hostname
 from ..socket import ClusterSocket
 from ..constants import PORT, SLAVE_PING_INTERVAL, MASTER_AVAILABILITY_CHECK_INTERVAL
 from ..cluster_pb2 import Wrapper
@@ -52,7 +53,7 @@ class ClusterSlave(ClusterSocket):
     async def update_state(self) -> None:
         """Update state of the slave socket."""
         message = self.build_message()
-        message.serviceAnnouncement.hostname = gethostname()
+        message.serviceAnnouncement.hostname = get_hostname()
 
         while self.running:
             # send service announcement if not yet acquired

--- a/backend/src/sonos/adapter.py
+++ b/backend/src/sonos/adapter.py
@@ -1,16 +1,11 @@
 """Defines methods to send commands to Sonos speakers"""
 from abc import ABC, abstractmethod
 from typing import Set
-from socket import gethostname, gethostbyname
 from models.speaker import Speaker
 
 
 class SonosAdapter(ABC):
     """Defines methods to send commands to Sonos speakers"""
-
-    def __init__(self):
-        self.calibration_sound_uri = 'http://{}:{}/backend-assets/white_noise.mp3'.format(
-            gethostbyname(gethostname()), 8079)
 
     @abstractmethod
     def discover(self) -> Set[Speaker]:

--- a/backend/src/sonos/adapter_soco.py
+++ b/backend/src/sonos/adapter_soco.py
@@ -1,10 +1,11 @@
 """Defines methods to send commands to Sonos speakers using the soco library"""
 from typing import Set, List
-from models.speaker import Speaker
 import soco
 from soco import events_asyncio
 from soco.snapshot import Snapshot
 from soco.events_asyncio import Subscription
+from models.speaker import Speaker
+from networking.helpers import get_ip_address
 from .adapter import SonosAdapter
 
 
@@ -75,8 +76,10 @@ class SonosSocoAdapter(SonosAdapter):
 
         :param models.speaker.Speaker speaker: Speaker on which calibration sound should be played on
         """
+        calibration_sound_uri = 'http://{}:{}/backend-assets/white_noise.mp3'.format(
+            get_ip_address(), 8079)
         soco_instance = self.get_coordinator_instance(speaker)
-        soco_instance.play_uri(uri=self.calibration_sound_uri, title='RS Calibration Sound')
+        soco_instance.play_uri(uri=calibration_sound_uri, title='RS Calibration Sound')
         soco_instance.play_mode = 'REPEAT_ONE'
 
     def save_snapshot(self, speaker: Speaker):


### PR DESCRIPTION
Resolves #75 

The hostname and IP address are now resolved more reliably and just when they are used (not cached at the start of real stereo). This should now also survive network changes, such as when switching from the ad hoc network to a real one.