### PR TITLE
Start at color index+1 & change lightness instead of saturation for volume

### DIFF
--- a/frontend/src/services/canvasDrawTools.tsx
+++ b/frontend/src/services/canvasDrawTools.tsx
@@ -18,12 +18,12 @@ export const mapCoordinate = (cord: number, canvasSize: number): number => {
   return Math.round((cord / maxCord) * canvasSize) + 0.5;
 }
 
-export const getRandomHexColourString = (index: number, saturation: number): string => {
-  const maxAmountOfColours = 16;
+export const getRandomHexColourString = (index: number, lightness: number): string => {
+  const maxAmountOfColours = 12;
   const hueDelta = Math.trunc(360 / maxAmountOfColours);
-  const h = (index % maxAmountOfColours) * hueDelta;
-  let s = saturation;
-  let l = 40;
+  const h = (index+1 % maxAmountOfColours) * hueDelta;
+  let s = 100;
+  let l = lightness * 0.5;
 
   // convert hsl to rgb from: https://css-tricks.com/converting-color-spaces-in-javascript/
   s /= 100;

--- a/frontend/src/services/roomCalibration.tsx
+++ b/frontend/src/services/roomCalibration.tsx
@@ -67,7 +67,10 @@ export const useRoomCalibration = (roomId: number, calibrationMapCanvasRef: RefO
         
         const speakerIdSet: Set<string> = new Set();
         roomCalibration.previousPoints.forEach(previousPoint => speakerIdSet.add(previousPoint.speaker_id));
-        drawInterpolation(context, canvasSize, roomCalibration.previousPoints.filter(prevPoint => prevPoint.speaker_id === selectedCalibrationMapSpeakerId), Array.from(speakerIdSet).indexOf(selectedCalibrationMapSpeakerId));
+        const previousPointsForSelectedSpeaker = roomCalibration.previousPoints.filter(prevPoint => prevPoint.speaker_id === selectedCalibrationMapSpeakerId);
+        if (previousPointsForSelectedSpeaker.length > 0) {
+          drawInterpolation(context, canvasSize, previousPointsForSelectedSpeaker, Array.from(speakerIdSet).indexOf(selectedCalibrationMapSpeakerId));
+        }
         drawPoints(context, canvasSize, roomCalibration.previousPoints, '#555555');
         drawPoints(context, canvasSize, roomCalibration.currentPoints, '#000000');
         drawCurrentPosition(context, canvasSize, mapCoordinate(roomCalibration.positionX, canvasSize), mapCoordinate(roomCalibration.positionY, canvasSize));


### PR DESCRIPTION
This should fix #81 by starting the color at `index+1` (thus avoiding red).
Additionally this changes to adjusting the lightness of the HSL color instead of the saturation for the interpolation values. This should provide a better visual difference for interpreting the interpolation result. 