### PR TITLE
Don't handle volume changes during calibration

### DIFF
--- a/backend/src/balancing/manager.py
+++ b/backend/src/balancing/manager.py
@@ -155,7 +155,7 @@ class BalancingManager:
         """
         def handle_event(event):
             if room.room_id not in self.room_info or \
-                    not room.calibrating or \
+                    room.calibrating or \
                     self.room_info[room.room_id]['current_volume'] is None:
                 return
 


### PR DESCRIPTION
This should fix #80. This took ages to figure out... I finally realised that a lot more volume changes were sent per `nextSpeaker` update from the frontend than anticipated, so I dug deeper and figured out that the volume change handler was responsible for sending weird volume updates during calibration.
It interestingly only happened when the speakers were setup in a stereo pair. That's why I haven't caught this one sooner.
I'm guessing the `not` was a typo? Or do we actually need to track the volume changes during calibration?