### PR TITLE
Remove unavailable speakers

### DIFF
--- a/backend/src/balancing/sonos.py
+++ b/backend/src/balancing/sonos.py
@@ -56,7 +56,7 @@ class Sonos:
             # delete speakers that have missed 2 discovery cycles
             for speaker in self.config.speakers:
                 if speaker.times_discovery_missed >= 2:
-                    await self.config.speaker_repository.remove_speaker(speaker.speaker_id)
+                    await self.config.speaker_repository.remove_speaker(speaker.speaker_id, delete_from_runtime_store=True)
 
             await asyncio.sleep(15)
 

--- a/backend/src/balancing/volume_interpolation.py
+++ b/backend/src/balancing/volume_interpolation.py
@@ -26,6 +26,9 @@ class VolumeInterpolation:
         self.speakers = []
 
         for point in self.room.calibration_points:
+            if point.speaker is None:
+                continue
+
             if point.speaker.speaker_id not in self.calibration_points:
                 self.calibration_points[point.speaker.speaker_id] = []
                 self.speakers.append(point.speaker)

--- a/backend/src/models/room_calibration_point.py
+++ b/backend/src/models/room_calibration_point.py
@@ -11,8 +11,9 @@ class RoomCalibrationPoint:
     :param float measured_volume: The measured volume of the sample
     """
     def __init__(self, speaker: Speaker, coordinate_x: int, coordinate_y: int, 
-                 measured_volume: float):
+                 measured_volume: float, speaker_id: str = None):
         self.speaker: Speaker = speaker
+        self.old_speaker_id: str = speaker_id
         self.coordinate_x: int = coordinate_x
         self.coordinate_y: int = coordinate_y
         self.measured_volume: float = measured_volume
@@ -27,7 +28,9 @@ class RoomCalibrationPoint:
         :rtype: RoomCalibrationPoint
         """
         speaker = config.speaker_repository.get_speaker(data.get('speaker_id'))
-        return RoomCalibrationPoint(speaker, data.get('coordinateX'), data.get('coordinateY'), data.get('measuredVolume'))
+        return RoomCalibrationPoint(speaker, data.get('coordinateX'), 
+                                    data.get('coordinateY'), data.get('measuredVolume'), 
+                                    speaker_id=data.get('speaker_id') if speaker is None else None)
 
     def to_json(self, recursive: bool = False) -> dict:
         """Creates a JSON serializable object.
@@ -44,9 +47,11 @@ class RoomCalibrationPoint:
             'measuredVolume': self.measured_volume,
         }
 
-        if recursive:
+        if recursive and self.speaker is not None:
             json['speaker'] = self.speaker.to_json()
-        else:
+        elif self.speaker is not None:
             json['speaker_id'] = self.speaker.speaker_id
+        else:
+            json['speaker_id'] = self.old_speaker_id
 
         return json

--- a/backend/src/models/speaker.py
+++ b/backend/src/models/speaker.py
@@ -22,6 +22,7 @@ class Speaker:
         self.name: str = name
         self.ip_address: str = ip_address
         self.room: models.room.Room = room
+        self.times_discovery_missed: int = -1
 
     @staticmethod
     def from_json(data: dict, config):

--- a/backend/src/repositories/speaker.py
+++ b/backend/src/repositories/speaker.py
@@ -32,10 +32,13 @@ class SpeakerRepository(Repository):
         """
         return next(filter(lambda s: s.name == name, self.config.speakers), None)
 
-    async def remove_speaker(self, speaker_id: str) -> bool:
+    async def remove_speaker(self, speaker_id: str, delete_from_runtime_store: bool = False) -> bool:
         """Removes a speaker and stores the config file.
 
         :param str speaker_id: Speaker id
+        :param bool delete_from_runtime_Store: If True speaker will be completly removed from the
+                                               config runtime store. If the speaker is discovered
+                                               in the next discovery round, it will be added again.
         :returns: False if no speaker could be found with this id and so no removal was possible,
                   otherwise True.
         :rtype: bool
@@ -45,6 +48,8 @@ class SpeakerRepository(Repository):
         if speaker is not None:
             # remove speaker
             speaker.room = None
+            if delete_from_runtime_store:
+                self.config.speakers.remove(speaker)
             await self.call_listeners()
 
             return True


### PR DESCRIPTION
This PR removes all Sonos speakers which haven't been discovered for 2 rounds from the system. It should keep the calibration points though so if the speaker is available again and readded by the user to the room no recalibration is needed.
It should fix #76 