### PR TITLE
Add more test mode settings

### DIFF
--- a/backend/src/balancing/manager.py
+++ b/backend/src/balancing/manager.py
@@ -105,7 +105,13 @@ class BalancingManager:
         for index, speaker in enumerate(room.volume_interpolation.speakers):
             perceived_volume = room.volume_interpolation.calculate_perceived_volume(speaker)
             speaker_volume = room.volume_interpolation.calculate_speaker_volume(perceived_volume)
-            speaker_volumes.append(speaker_volume)
+
+            if self.config.test_mode and self.config.test_mode_speaker is not None \
+                    and self.config.test_mode_speaker != speaker.speaker_id:
+                speaker_volumes.append(0)
+            else:
+                speaker_volumes.append(speaker_volume)
+
             if self.room_info[speaker.room.room_id]['master_ip_address'] == speaker.ip_address and \
                     index != self.room_info[speaker.room.room_id]['master_index']:
                 self.room_info[speaker.room.room_id]['master_index'] = index
@@ -156,6 +162,7 @@ class BalancingManager:
         def handle_event(event):
             if room.room_id not in self.room_info or \
                     room.calibrating or \
+                    not self.config.balance or \
                     self.room_info[room.room_id]['current_volume'] is None:
                 return
 

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -28,6 +28,7 @@ class Config:
         self.balance: bool = False
         self.network = 'client'
         self.test_mode: bool = False
+        self.test_mode_speaker: str = None
         self.rooms: List[Room] = []
         self.nodes: List[Node] = []
         self.speakers: List[Speaker] = []

--- a/documents/web-protocol.md
+++ b/documents/web-protocol.md
@@ -123,6 +123,7 @@ type Settings = {
 type UpdateSettings = {
   balance?: boolean;
   testMode?: boolean;
+  testModeSpeaker?: string;
   nodeType?: 'master' | 'tracking';
   network?: CreateNetwork;
 }

--- a/frontend/src/pages/TestMode/index.tsx
+++ b/frontend/src/pages/TestMode/index.tsx
@@ -2,15 +2,19 @@ import { Row, Col, Switch, Divider, Progress, Space, Alert, Select, Spin, Button
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useAudioMeter } from '../../services/audioMeter';
 import { useRooms } from '../../services/rooms';
+import { useSpeakers } from '../../services/speakers';
 import { useTestMode } from '../../services/testMode';
 import styles from './styles.module.css';
 
 const TestModePage: FunctionComponent = () => {
   const { rooms } = useRooms();
+  const { speakers } = useSpeakers();
   const [testModeEnabled, setTestModeEnabled] = useState(false);
+  const [balancing, setBalancing] = useState(false);
+  const [testModeSpeaker, setTestModeSpeaker] = useState<string | null>(null);
   const [testModeRoomId, setTestModeRoomId] = useState<number>();
   const testModeMapCanvasRef = useRef<HTMLCanvasElement>(null);
-  const {readyToTestLocation, measurePoint, errors} = useTestMode(testModeEnabled, testModeMapCanvasRef, testModeRoomId);
+  const { readyToTestLocation, measurePoint, errors } = useTestMode(testModeEnabled, balancing, testModeSpeaker, testModeMapCanvasRef, testModeRoomId);
   const spectrumAnalyzerCanvasRef = useRef<HTMLCanvasElement>(null);
   const { volume, audioMeterErrors } = useAudioMeter(testModeEnabled, spectrumAnalyzerCanvasRef);
 
@@ -33,6 +37,28 @@ const TestModePage: FunctionComponent = () => {
           <Switch onChange={setTestModeEnabled} />
         </Col>
       </Row>
+      <Row className={styles.settingRow}>
+        <Col flex="auto">Enable balancing</Col>
+        <Col>
+          <Switch onChange={setBalancing} />
+        </Col>
+      </Row>
+      <Row className={styles.settingRow}>
+        <Col span={12}>Enabled speakers</Col>
+        <Col flex="auto">
+          <Select
+            className={styles.select}
+            labelInValue
+            onChange={(option: any) => setTestModeSpeaker(option.value)}
+            defaultValue={{ label: 'All', value: '' }}
+          >
+            <Select.Option key="all" value={''}>All</Select.Option>
+            {speakers?.map(speaker =>
+              <Select.Option key={speaker.id} value={speaker.id}>{speaker.name}</Select.Option>
+            )}
+          </Select>
+        </Col>
+      </Row>
       <Divider />
       <Space direction="vertical" style={{ width: '100%' }}>
         <Row>
@@ -52,17 +78,17 @@ const TestModePage: FunctionComponent = () => {
             <Select
               className={styles.select}
               labelInValue
-              onChange={(option: any) => {setTestModeRoomId(option.value)}}
-              defaultValue={{label: rooms[0].name, value: rooms[0].id}}>
-                {rooms.map(room =>
-                  <Select.Option key={room.id} value={room.id}>{room.name}</Select.Option>
-                )}
+              onChange={(option: any) => { setTestModeRoomId(option.value) }}
+              defaultValue={{ label: rooms[0].name, value: rooms[0].id }}>
+              {rooms.map(room =>
+                <Select.Option key={room.id} value={room.id}>{room.name}</Select.Option>
+              )}
             </Select>
           </Col>
           <Col>
             <Button type="primary" onClick={measurePoint} disabled={!testModeEnabled} loading={!readyToTestLocation && testModeEnabled}>Measure volume</Button>
           </Col>
-        </Row> : <Row justify="center"><Spin /></Row> }
+        </Row> : <Row justify="center"><Spin /></Row>}
         <Divider />
         <Row>
           <Col flex="none">Spectrum Analyzer</Col>

--- a/frontend/src/pages/TestMode/styles.module.css
+++ b/frontend/src/pages/TestMode/styles.module.css
@@ -8,3 +8,7 @@
     width: 100%;
     height: auto;
 }
+
+.settingRow {
+    margin-top: 16px;
+}

--- a/frontend/src/services/settings.tsx
+++ b/frontend/src/services/settings.tsx
@@ -16,6 +16,7 @@ export type UpdateSettings = {
   nodeType?: 'master' | 'tracking';
   network?: CreateNetwork;
   testMode?: boolean;
+  testModeSpeaker?: string;
 }
 
 export type SettingsTestModeResult = {

--- a/frontend/src/services/testMode.tsx
+++ b/frontend/src/services/testMode.tsx
@@ -12,14 +12,14 @@ type TestPoint = {
   volume: number;
 }
 
-export const useTestMode = (enabled: boolean, testModeMapCanvasRef: RefObject<HTMLCanvasElement> | null = null, mapCanvasRoomId: number | null = null) => {
+export const useTestMode = (enabled: boolean, balance: boolean, testModeSpeaker: string | null = null, testModeMapCanvasRef: RefObject<HTMLCanvasElement> | null = null, mapCanvasRoomId: number | null = null) => {
   const { settingsTestModeResult, updateSettings } = useSettings();
 
   const [errors, setErrors] = useState<string[]>([]);
   const [readyToTestLocation, setReadyToTestLocation] = useState(false);
   const [testPoints, setTestPoints] = useState<TestPoint[]>([]);
 
-  const drawTestModeMap = useCallback((result: SettingsTestModeResult | undefined) => {
+  const drawTestModeMap = useCallback((result: SettingsTestModeResult | undefined) => {
     const testModeMapContext = testModeMapCanvasRef?.current?.getContext('2d');
     if (testModeMapContext) {
       testModeMapContext.clearRect(0, 0, testModeMapCanvasSize, testModeMapCanvasSize);
@@ -45,9 +45,9 @@ export const useTestMode = (enabled: boolean, testModeMapCanvasRef: RefObject<HT
         });
 
         drawCurrentPosition(
-          testModeMapContext, 
-          testModeMapCanvasSize, 
-          mapCoordinate(result.positionX, testModeMapCanvasSize), 
+          testModeMapContext,
+          testModeMapCanvasSize,
+          mapCoordinate(result.positionX, testModeMapCanvasSize),
           mapCoordinate(result.positionY, testModeMapCanvasSize)
         );
       }
@@ -67,7 +67,7 @@ export const useTestMode = (enabled: boolean, testModeMapCanvasRef: RefObject<HT
 
       try {
         if (enabled) {
-          await updateSettings({ testMode: true, balance: true });
+          await updateSettings({ testMode: true, balance, testModeSpeaker: testModeSpeaker || undefined });
           disableHistoricVolume();
           setReadyToTestLocation(true);
         } else {
@@ -79,10 +79,10 @@ export const useTestMode = (enabled: boolean, testModeMapCanvasRef: RefObject<HT
     })();
 
     return () => {
-      updateSettings({ testMode: false });
+      updateSettings({ testMode: false, balance: false });
       setTestPoints([]);
     }
-  }, [enabled, updateSettings, testModeMapCanvasRef]);
+  }, [enabled, balance, testModeSpeaker, updateSettings, testModeMapCanvasRef]);
 
   useEffect(() => {
     if (!settingsTestModeResult) return;


### PR DESCRIPTION
This allows us to perform more tests for the documentation.
For example, we can compare the volume in the room when the balancing is active and when it is disabled (balancing is no longer automatically enabled when starting the test mode).
Also, we can now record the value of a single speaker as it should also have the same volume in the whole room.

(it can take a few seconds when a speaker gets disabled)